### PR TITLE
Change mac publish to use 64 bit electron builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "publish:win64": "build --win -p always --config electron-builder64.yml",
     "publish:win32": "build --win -p always --config electron-builder.yml",
     "publish:win": "npm run publish:win32 && npm run publish:win64",
-    "publish:mac": "build --mac -p always --config electron-builder.yml",
+    "publish:mac": "build --mac -p always --config electron-builder64.yml",
     "publish:lin": "build --linux -p always --config electron-builder.yml"
   },
   "repository": "https://github.com/adlerluiz/ytmdesktop",


### PR DESCRIPTION
Fix #52 

The latest version of electron builder has no support for Mac OS 32 bit so it's necessary to switch to a 64 bit build.