### PR TITLE
Fix: Unsafe browser on Login with User Agent

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,6 +138,9 @@ function createWindow() {
     }
   }
   mainWindow = new BrowserWindow(broswerWindowConfig);
+  mainWindow.webContents.session.setUserAgent(
+    "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/71.0"
+  );
   const view = new BrowserView({
     webPreferences: {
       nodeIntegration: true,


### PR DESCRIPTION
A temporary fix to the issue #67.
This is a known issue on all Chromium-based browsers due to the recent changes that Google is rolling out. More info at https://security.googleblog.com/2019/04/better-protection-against-man-in-middle.html

The bug was replicable by almost all users on other Electron applications such as Google Play Music Desktop Application, etc.

Current Fix:
- Using the latest Mozilla Firefox's User Agent on the main browser window instead of the Chromium's default one.

Files Changed:
- main.js