### PR TITLE
Added tr localization to language options

### DIFF
--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -152,6 +152,7 @@
                         <option value="ru">русский</option>
                         <option value="ukr">Українська</option>
                         <option value="nl">Nederlands</option>
+                        <option value="tr">Türkçe</option>
                       </select>
                     </td>
                   </tr>


### PR DESCRIPTION
There is a `tr.json` in `locales` folder but not added to select menu.