### PR TITLE
:bug: fix incorrect size on mac tray icon

### DIFF
--- a/src/providers/trayProvider.js
+++ b/src/providers/trayProvider.js
@@ -30,7 +30,7 @@ let init_tray = () => {
         doBehavior(saved_mainWindow)
     })
 
-    tray.addListener('balloon-click', function() {
+    tray.addListener('balloon-click', function () {
         doBehavior(saved_mainWindow)
     })
 }
@@ -38,7 +38,7 @@ let init_tray = () => {
 let popUpMenu = null
 
 function createTray(mainWindow, icon) {
-    let nativeImageIcon = nativeImage.createFromPath(icon)
+    nativeImageIcon = buildTrayIcon(icon)
     tray = new Tray(nativeImageIcon)
 
     saved_mainWindow = mainWindow
@@ -51,6 +51,11 @@ function createTray(mainWindow, icon) {
 }
 
 function updateTrayIcon(icon) {
+    nativeImageIcon = buildTrayIcon(icon)
+    tray.setImage(nativeImageIcon)
+}
+
+function buildTrayIcon(icon) {
     let nativeImageIcon = nativeImage.createFromPath(icon)
     if (systemInfo.isMac()) {
         nativeImageIcon = nativeImageIcon.resize({
@@ -59,14 +64,14 @@ function updateTrayIcon(icon) {
             quality: 'best',
         })
     }
-    tray.setImage(nativeImageIcon)
+    return nativeImageIcon
 }
 
 function balloon(title, content, cover, icon) {
     if (title && content && cover) {
         imageToBase64(cover)
             .then(
-                response => {
+                (response) => {
                     _doNotification(
                         title,
                         content,
@@ -75,7 +80,7 @@ function balloon(title, content, cover, icon) {
                         )
                     )
                 },
-                _ => {
+                (_) => {
                     _doNotification(
                         title,
                         content,
@@ -83,7 +88,7 @@ function balloon(title, content, cover, icon) {
                     )
                 }
             )
-            .catch(_ => {
+            .catch((_) => {
                 _doNotification(
                     title,
                     content,
@@ -160,7 +165,6 @@ function setShinyTray() {
         })
     } else {
         // Shiny tray disabled ||| on onther platform
-        tray.setImage(saved_icon)
         tray.removeAllListeners()
         init_tray()
     }


### PR DESCRIPTION
#195 
Apply scaling for tray icon on macOS
Also, slightly refactor code:
- Remove redunant set of icon in setShinyTray method as we already did it in createTray
- Move nativeImageIcon building to separate method to reuse it