### PR TITLE
:lipstick: Make next song notifications silent

### DIFF
--- a/src/providers/trayProvider.js
+++ b/src/providers/trayProvider.js
@@ -96,10 +96,12 @@ function _doNotification(title, content, image) {
                 icon: image,
                 title: title,
                 content: content,
+                noSound = true,
             })
         } else {
             new Notification(title, {
                 body: content,
+                silent = true,
                 icon: image,
             })
         }


### PR DESCRIPTION
Notifications about new song playing may distract. In GPM desktop, for example, such notifications are silent.