### PR TITLE
✨ Accent Color Enhancements and Bugfixes

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -25,10 +25,14 @@ html, body {
     top: 0;
     left: 0;
     right: 0;
-    /*background-color: #232323;*/
+    background-color: #232323;
     width: 100%;
-    height: 28px;
-    max-height: 28px;
+    height: 30px;
+    max-height: 30px;
+}
+
+body[accent-enabled][player-open] .bar{
+    background-color: var(--ytm-album-color-muted);
 }
 
 .bar .title {

--- a/src/utils/calcYTViewSize.js
+++ b/src/utils/calcYTViewSize.js
@@ -20,6 +20,15 @@ function calculateYoutubeViewSize(store, window) {
 
     const x = PADDING
 
+    if (window.isFullScreen()) {
+        return {
+            x: 0,
+            y: 0,
+            width: windowSize[0],
+            height: windowSize[1],
+        }
+    }
+
     if (isMac()) {
         // IS MAC
         const y = isNiceTitleBarDisabled


### PR DESCRIPTION
✨ Apply accent color changes from player page to 'nice' title bar. (Color will not apply to system title bars)
🐛 Fix issue where 'continue where you left off' setting would not apply the accent color changes to the first song played on startup.
🐛 'Nice' titlebar now disappears correctly when a video or song goes fullscreen
📱 Increase height of 'nice' title bar to remove stray border, change default color to match the top bar of YTM, #232323.
✏️ Remove stray HSL debug statement from previous PR.