### PR TITLE
:bug: JavaScript Errors in updateActivity

### DIFF
--- a/src/providers/infoPlayerProvider.js
+++ b/src/providers/infoPlayerProvider.js
@@ -72,6 +72,7 @@ function getPlayerInfo() {
     getSeekbarPosition(webContents)
     getLikeStatus(webContents)
     getRepeatType(webContents)
+    return player
 }
 
 function getTrackInfo() {
@@ -86,6 +87,7 @@ function getTrackInfo() {
     setPercent(player.seekbarCurrentPosition, track.duration)
     isVideo(webContents)
     isAdvertisement(webContents)
+    return track
 }
 
 function getQueueInfo() {


### PR DESCRIPTION
Fix JS error in `updateActivity` by making `infoPlayerProvider.getPlayerInfo()` and `infoPlayerProvider.getTrackInfo()` actually return the player and track, respectively. These had been broken by a refactor in  b15b2ff.