### PR TITLE
Scrobble albums

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3839,10 +3839,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "scribble": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/scribble/-/scribble-0.0.5.tgz",
-            "integrity": "sha1-IRmrA5Old8nUchr1Q+cU5ID9wNs="
-        },
+            "version": "github:dittodhole/node-scribble-js#a2b37f585c5382863319115db36201399477ed43",
+            "from": "github:dittodhole/node-scribble-js#a2b37f585c5382863319115db36201399477ed43"
+        },        
         "semver": {
             "version": "7.3.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "node-vibrant": "^3.1.5",
         "qrcode-generator": "^1.4.4",
         "register-scheme": "0.0.2",
-        "scribble": "0.0.5",
+        "scribble": "github:dittodhole/node-scribble-js#a2b37f585c5382863319115db36201399477ed43",
         "socket.io": "^2.3.0",
         "uuid": "^8.3.0",
         "ws": "^7.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,10 +3060,10 @@ sax@>=0.6.0, sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scribble@0.0.5:
+"scribble@github:dittodhole/node-scribble-js#a2b37f585c5382863319115db36201399477ed43":
   version "0.0.5"
-  resolved "https://registry.yarnpkg.com/scribble/-/scribble-0.0.5.tgz#2119ab0393a577c9d4721af543e714e480fdc0db"
-  integrity sha1-IRmrA5Old8nUchr1Q+cU5ID9wNs=
+  resolved "https://codeload.github.com/dittodhole/node-scribble-js/tar.gz/a2b37f585c5382863319115db36201399477ed43"
+
 
 semver-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Use unpublished fork of scribble that correctly scrobbles albums
The only downside to this is that the git repo may be deleted at any moment (very unlikely to happen).

https://github.com/dittodhole/node-scribble-js/tree/a2b37f585c5382863319115db36201399477ed43
