### PR TITLE
This adds play and pause event handling to the mpris providers

### DIFF
--- a/main.js
+++ b/main.js
@@ -517,6 +517,9 @@ function createWindow() {
                 lastIsPaused = playerInfo.isPaused
 
                 discordRPC.setActivity(getAll())
+                if (isLinux()) {
+                    mprisProvider.setActivity(getAll())
+                }
 
                 if (!isMac() && !settingsProvider.get('settings-shiny-tray')) {
                     tray.updateTrayIcon(

--- a/src/providers/mprisProvider.js
+++ b/src/providers/mprisProvider.js
@@ -6,6 +6,7 @@ class Mpris {
         this._isInitialized = false
         this.player = undefined
         this._realPlayer = undefined //we'll need the infoPlayer later to be better able to track the time.
+        this._isPaused = undefined
     }
 
     start() {
@@ -47,6 +48,25 @@ class Mpris {
                 ? mpris.PLAYBACK_STATUS_PAUSED
                 : mpris.PLAYBACK_STATUS_PLAYING
         }
+        this._isPaused = info.player.isPaused
+    }
+
+    pause() {
+        if (!this._isPaused) {
+            ipcMain.emit('media-command', {
+                command: 'media-play-pause',
+                value: true,
+            })
+        }
+    }
+
+    play() {
+        if (this._isPaused) {
+            ipcMain.emit('media-command', {
+                command: 'media-play-pause',
+                value: true,
+            })
+        }
     }
 
     _setInitialEvents() {
@@ -54,8 +74,8 @@ class Mpris {
             quit: () => process.exit(0),
             previous: 'media-track-previous',
             next: 'media-track-next',
-            pause: 'media-play-pause',
-            play: 'media-play-pause',
+            pause: this.pause,
+            play: this.play,
             playpause: 'media-play-pause', //KDE Connect only sends this event it looked like.
         }
 


### PR DESCRIPTION
Adding the play and pause events in addition to the play-pause
event. This makes it easier to pause the player externally if you
don't have access to the current status.

I am using an instance variable, because this.player.playbackStatus
doesn't seem to be available all of the time.

This fixes #440

JavaScript is not my first language, so I would be happy about any feedback. 