### PR TITLE
Adds shutdown button

### DIFF
--- a/main.js
+++ b/main.js
@@ -988,6 +988,13 @@ async function createWindow() {
         tray.setShinyTray()
     })
 
+    ipcMain.on('closed', (_) => {
+        mainWindow = null
+        if (process.platform !== 'darwin') {
+            app.quit()
+        }
+    })
+
     ipcMain.on('btn-update-clicked', () => {
         updater.quitAndInstall()
     })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,7 @@
     "LABEL_SETTINGS_TAB_SHORTCUTS_VOLUME_MEDIA_KEYS": "Volume media keys only control app volume",
     "LABEL_SETTINGS_TAB_PLAYBACK_DECIBEL_VOLUME": "Switch volume control from '%' to 'dB'",
     "LABEL_SETTINGS": "Settings",
+    "LABEL_SHUTDOWN": "Shutdown",
     "LYRICS": "Lyrics",
     "MEDIA_CONTROL_MINIPLAYER": "Open/Close Miniplayer",
     "MEDIA_CONTROL_MUTE_UNMUTE": "Mute/Unmute",

--- a/src/utils/injectControls.js
+++ b/src/utils/injectControls.js
@@ -302,6 +302,24 @@ function createTopRightContent() {
     try {
         const right_content = document.getElementById('right-content')
 
+        //SHUTDOWN
+        const elementShutdown = document.createElement('i')
+        elementShutdown.id = 'ytmd_shutdown'
+        elementShutdown.title = translate('LABEL_SHUTDOWN')
+        elementShutdown.classList.add(
+            'material-icons',
+            'pointer',
+            'shine',
+            'ytmd-icons'
+        )
+        elementShutdown.innerText = 'power_settings_new'
+
+        elementShutdown.addEventListener('click', function () {
+            ipcRenderer.send('closed')
+        })
+
+        right_content.prepend(elementShutdown)
+
         // SETTINGS
         const elementSettings = document.createElement('i')
         elementSettings.id = 'ytmd_settings'


### PR DESCRIPTION
This adds a button next to the settings button that allows to close the player completely. This is the best placement I found even though it might be better to add it to the popup menu that opens when you click your usericon. Unfortunately I was not able to do that, so if you want that there you will have to point me in the right direction

Fixes #418 