### PR TITLE
Make MPRIS work with Ubuntu snapped version

### DIFF
--- a/electron-builder-deploy64.yml
+++ b/electron-builder-deploy64.yml
@@ -45,3 +45,7 @@ mac:
 linux:
   icon: src/assets/favicon.png
   category: AudioVideo
+
+snap:
+  slots: 
+    - mpris

--- a/src/providers/mprisProvider.js
+++ b/src/providers/mprisProvider.js
@@ -10,7 +10,7 @@ class Mpris {
 
     start() {
         this.player = new mpris({
-            name: 'youtubemusic',
+            name: 'youtube-music-desktop-app',
             identity: 'Youtube Music',
             supportedUriSchemes: ['file'],
             supportedMimeTypes: ['audio/mpeg', 'application/ogg'],
@@ -36,7 +36,9 @@ class Mpris {
     setActivity(info) {
         if (this._isInitialized) {
             this.player.metadata = {
-                'mpris:trackid': this.player.objectPath('track/0'),
+                'mpris:trackid': this.player
+                    .objectPath('track/0')
+                    .replaceAll('-', '_'), // replacing -'s in name with _ to meet dbus object name spec
                 'mpris:length': info.track.duration * 1000 * 1000, // In microseconds
                 'mpris:artUrl': info.track.cover,
                 'xesam:title': info.track.title,


### PR DESCRIPTION
Made MPRIS handlers work when the app is snapped. Added MPRIS slot to electron builder config. Renamed MPRIS player name to match default MPRIS slot. Rework player MPRIS metadata to work with new name.

Addresses #443