### PR TITLE
:bug: Fix stepless volume control

### DIFF
--- a/src/providers/infoPlayerProvider.js
+++ b/src/providers/infoPlayerProvider.js
@@ -443,6 +443,7 @@ function setVolume(webContents, time) {
             `
         var slider = document.querySelector('#volume-slider');
         slider.value = ${time};
+        document.querySelector('.video-stream').volume = ${time / 100}
         `
         )
         .then()


### PR DESCRIPTION
Last month I created pull request #374. Part of that improvement was the removal of the 5% increments on the volume slider.

Something broke since then and it is now impossible to control the volume to more than 1% accuracy. This means that it is impossible to set the volume to 0.5% or 1.5%.

This fix removes the 1% increments.