### PR TITLE
Fix settings are not saved bug

### DIFF
--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -283,8 +283,6 @@ function showRelaunchButton() {
  * @param {*} fn
  */
 function initElement(elementName, eventType, fn) {
-    if (fn === undefined) fn = () => {}
-
     const element = document.getElementById(elementName)
 
     if (element) {
@@ -301,10 +299,10 @@ function initElement(elementName, eventType, fn) {
  * @param {*} fn
  */
 function createListener(element, settingsName, eventType, fn) {
-    element.addEventListener(eventType, () => {
+    element.addEventListener(eventType, (e) => {
         switch (eventType) {
             case 'click':
-                settingsProvider.set(settingsName, this.checked)
+                settingsProvider.set(settingsName, e.target.checked)
                 /*ipc.send('settings-value-changed', {
                     key: settingsName,
                     value: this.checked,
@@ -312,14 +310,14 @@ function createListener(element, settingsName, eventType, fn) {
                 break
 
             case 'change':
-                settingsProvider.set(settingsName, this.value)
+                settingsProvider.set(settingsName, e.target.value)
                 /*ipc.send('settings-value-changed', {
                     key: settingsName,
                     value: this.value,
                 })*/
                 break
         }
-        fn()
+        fn && fn()
     })
 }
 


### PR DESCRIPTION
Fix for the regression introduced in #416

The function context was changed due to moving to arrow function so I fixed this part.
![image](https://user-images.githubusercontent.com/34966497/97646374-1fecf800-1a58-11eb-99eb-d6899110f0c4.png)


As now `null` is passed as the fn parameter I removed the check on undefined and added a check before the callback call.
![image](https://user-images.githubusercontent.com/34966497/97646567-ad304c80-1a58-11eb-9787-b7fde5ae2769.png)


