### PR TITLE
Fix double wheel scrolling on volume

### DIFF
--- a/src/utils/injectControls.js
+++ b/src/utils/injectControls.js
@@ -698,8 +698,38 @@ function playerBarScrollToChangeVolume() {
     try {
         const playerBar = document.getElementsByTagName('ytmusic-player-bar')[0]
 
+        const volumeSlider = document.getElementById('volume-slider')
+        let isVolumeSliderHovered = false
+        volumeSlider.addEventListener(
+            'mouseover',
+            () => (isVolumeSliderHovered = true)
+        )
+        volumeSlider.addEventListener(
+            'mouseout',
+            () => (isVolumeSliderHovered = false)
+        )
+
+        const expandVolumeSlider = document.getElementById(
+            'expand-volume-slider'
+        )
+        let isExpandVolumeSliderHovered = false
+        expandVolumeSlider.addEventListener(
+            'mouseover',
+            () => (isExpandVolumeSliderHovered = true)
+        )
+        expandVolumeSlider.addEventListener(
+            'mouseout',
+            () => (isExpandVolumeSliderHovered = false)
+        )
+
+        const isSliderHovered = () =>
+            isExpandVolumeSliderHovered || isVolumeSliderHovered
+
         playerBar.addEventListener('wheel', (ev) => {
             ev.preventDefault()
+            if (!settingsGet('settings-decibel-volume') && isSliderHovered()) {
+                return
+            }
 
             if (ev.deltaY < 0)
                 ipcRenderer.send('media-command', {


### PR DESCRIPTION
Fix double wheel scroll.

During usage, I found that if I focus on the volume slider and scroll wheel the volume is increased twice(see gif below). So if I scroll wheel once it increases/decreases volume by 10% instead of 5. It repros for percent increasing so to test this you need to disable dB volume by default (#374).
![before](https://user-images.githubusercontent.com/34966497/97647080-00ef6580-1a5a-11eb-8b77-0d12b192071d.gif)

It happens because the event called two times: from youtube music(a default one) + custom event from `playerBarScrollToChangeVolume`.

I added checks on element hover(for both expanded and common slider) and now if the spinner has hovered then the app doesn't raise the second volume-change event.

I disabled this check for the dB feature as it will break its functionality. Also, I see a UI bug with enabled dB feature when I scroll wheel focusing on slider: the slider is flickering in this case.

Now it works properly. Demo gif below
![after](https://user-images.githubusercontent.com/34966497/97642048-f24e8180-1a4c-11eb-8dce-35673a3c59cc.gif)