### PR TITLE
:bug: wrong left-padding in main window on linux

### DIFF
--- a/src/utils/calcYTViewSize.js
+++ b/src/utils/calcYTViewSize.js
@@ -18,8 +18,6 @@ function calculateYoutubeViewSize(store, window) {
     const isNiceTitleBarDisabled = store.get('titlebar-type', 'nice') !== 'nice'
     const titlebarType = store.get('titlebar-type')
 
-    const x = PADDING
-
     if (window.isFullScreen())
         return {
             x: 0,
@@ -30,6 +28,7 @@ function calculateYoutubeViewSize(store, window) {
 
     if (isMac()) {
         // IS MAC
+        const x = PADDING
         const y = isNiceTitleBarDisabled
             ? PADDING + TITLE_BAR_HEIGHT_MAC
             : PADDING + TITLE_BAR_HEIGHT
@@ -42,6 +41,7 @@ function calculateYoutubeViewSize(store, window) {
         }
     } else if (isLinux()) {
         // IS LINUX
+        const x = PADDING_LINUX
         const y = PADDING_LINUX
 
         return {
@@ -52,6 +52,7 @@ function calculateYoutubeViewSize(store, window) {
         }
     } else {
         // IS WINDOWS
+        const x = PADDING
         const y = isNiceTitleBarDisabled ? PADDING : PADDING + TITLE_BAR_HEIGHT
 
         return {


### PR DESCRIPTION
The main window has a wrong left-padding on Linux that can be seen when you're using a light YT theme.
![Screenshot from 2020-11-01 00-46-03](https://user-images.githubusercontent.com/644735/97792355-48eac580-1bdd-11eb-947c-fb32bb36502c.png)
The proposed PR fixes this
![Screenshot from 2020-11-01 00-44-35](https://user-images.githubusercontent.com/644735/97792356-49835c00-1bdd-11eb-9c10-84ef11348c2e.png)
