### PR TITLE
:sparkles: added forward navigation

### DIFF
--- a/src/utils/injectControls.js
+++ b/src/utils/injectControls.js
@@ -270,22 +270,40 @@ function createTopMiddleContent() {
         )[0]
 
         // HISTORY BACK
-        const element = document.createElement('i')
-        element.id = 'ytmd_history_back'
-        element.classList.add(
+        const back_element = document.createElement('i')
+        back_element.id = 'ytmd_history_back'
+        back_element.classList.add(
             'material-icons',
             'pointer',
             'shine',
             'ytmd-icons',
             'center-content'
         )
-        element.innerText = 'keyboard_backspace'
+        back_element.innerText = 'keyboard_backspace'
 
-        element.addEventListener('click', function () {
+        back_element.addEventListener('click', function () {
             history.go(-1)
         })
 
-        center_content.prepend(element)
+        // HISTORY FORWARD
+        const forward_element = document.createElement('i')
+        forward_element.id = 'ytmd_history_forward'
+        forward_element.classList.add(
+            'material-icons',
+            'pointer',
+            'shine',
+            'ytmd-icons',
+            'center-content'
+        )
+        forward_element.style.cssText = 'transform: rotate(180deg);'
+        forward_element.innerText = 'keyboard_backspace'
+
+        forward_element.addEventListener('click', function () {
+            history.forward()
+        })
+
+        center_content.prepend(forward_element)
+        center_content.prepend(back_element)
     } catch (err) {
         console.error(err)
         ipcRenderer.send('log', {


### PR DESCRIPTION
I used to maintain `google-music-electron` and was surprised there wasn't a forward button for the back button. This PR resolves that. In this PR:

- Added forward navigation button next to back navigation button

Bonus:

- Not in this PR but it shouldn't be too hard to implement disable logic: https://github.com/twolfson/google-music-electron/blob/2.20.0/lib/browser.js#L77-L91

Screenshots:

**Before:**

![Selection_250](https://user-images.githubusercontent.com/902488/101702821-83464e80-3a36-11eb-8ab5-e41132556f66.png)

**After:**

![Selection_249](https://user-images.githubusercontent.com/902488/101702825-85a8a880-3a36-11eb-8309-1b2a5301e9c1.png)