### PR TITLE
Update last.fm scrobble value main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -409,12 +409,12 @@ function createWindow() {
             )
 
             /**
-             * Srobble when track changes or when current track starts from the beginning
+             * Scrobble when track changes or when current track starts from the beginning
              */
             if (settingsProvider.get('settings-last-fm-scrobbler')) {
                 if (
                     lastTrackId !== trackId ||
-                    (lastTrackProgress > progress && progress < 0.01)
+                    (lastTrackProgress > progress && progress < 0.20)
                 ) {
                     if (!trackInfo.isAdvertisement) {
                         clearInterval(updateTrackInfoTimeout)


### PR DESCRIPTION
change last.fm scrobble value to 20% track progress instead of 1%.
Avoids excessive scrobbling of tracks that get skipped.