### PR TITLE
Use mpris only as soon as media is playing

### DIFF
--- a/main.js
+++ b/main.js
@@ -111,8 +111,6 @@ if (
         console.log('error windowsMediaProvider > ' + error)
     }
 
-if (isLinux()) mprisProvider.start()
-
 if (isMac()) {
     settingsProvider.set(
         'settings-shiny-tray-dark',
@@ -364,7 +362,12 @@ async function createWindow() {
     view.webContents.on('media-started-playing', () => {
         if (!infoPlayerProvider.hasInitialized()) {
             infoPlayerProvider.init(view)
-            if (isLinux()) mprisProvider.setRealPlayer(infoPlayerProvider) //this lets us keep track of the current time in playback.
+            if (isLinux()) {
+                if (!mprisProvider._isInitialized) {
+                    mprisProvider.start()
+                }
+                mprisProvider.setRealPlayer(infoPlayerProvider) //this lets us keep track of the current time in playback.
+            }
         }
 
         if (


### PR DESCRIPTION
This is a fix that makes the mpris service startup only when necessary (a fix for LInux). 

Before the fix the controls showed upas soon as the program started which makes no sense since there is no media playing yet  (I only tried GNOME but I strongly suspect also other DEs). Now the player shows up in the notification area only after music starts playing