### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Mac
 
-- Brew: ```brew cask install ytmdesktop-youtube-music```
+- Brew: ```brew install --cask ytmdesktop-youtube-music```
 - Binaries: https://github.com/ytmdesktop/ytmdesktop/releases
 
 # To Contribute


### PR DESCRIPTION
Updated Readme with new Homebrew command for OSX install.  'Brew cask' is now deprecated 'brew install --cask' is now used.