### PR TITLE
Fix error not defined message at start up

### DIFF
--- a/src/providers/trayProvider.js
+++ b/src/providers/trayProvider.js
@@ -209,13 +209,13 @@ function setShinyTray() {
 
 function updateImage(payload) {
     try {
-        if (!settingsProvider.get('settings-shiny-tray')) return
+        if (!settingsProvider.get('settings-shiny-tray') || !tray) return
         const img =
             typeof nativeImage.createFromDataURL === 'function'
                 ? nativeImage.createFromDataURL(payload) // electron v0.36+
                 : nativeImage.createFromDataUrl(payload) // electron v0.30
         tray.setImage(img)
-    } catch (_) {
+    } catch (error) {
         ipcMain.emit('log', {
             type: 'warn',
             data: `Failed to updateImage: ${error}`,


### PR DESCRIPTION
Hi there,

I got exception "error is not defined" when the app open.
![image](https://user-images.githubusercontent.com/904461/106355739-7eae6000-632c-11eb-85eb-cc450e30dc77.png)

Made this simple changes to fix the issues. Also adding condition in the so the code doesn't throw exception when tray is null.