### PR TITLE
fix: Adding missing error param

### DIFF
--- a/src/providers/trayProvider.js
+++ b/src/providers/trayProvider.js
@@ -213,7 +213,7 @@ function updateImage(payload) {
                 ? nativeImage.createFromDataURL(payload) // electron v0.36+
                 : nativeImage.createFromDataUrl(payload) // electron v0.30
         tray.setImage(img)
-    } catch {
+    } catch (error) {
         ipcMain.emit('log', {
             type: 'warn',
             data: `Failed to updateImage: ${error}`,


### PR DESCRIPTION
Currently running into an issue where the try block above is throwing an error, but the error block is crashing the app because the error param is undefined on line 219. So this is simply putting the error param in the catch block so the error can emit properly.