### PR TITLE
⬆️  Bump electron to 11.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         }
     },
     "devDependencies": {
-        "electron": "^11.1.1",
+        "electron": "^11.2.1",
         "electron-builder": "^22.9.1",
         "electron-rebuild": "^2.3.4",
         "husky": "^4.3.7",


### PR DESCRIPTION
Electron 11.2.1 works greate on my Mac Mini(Intel) and MacBook Pro(Apple silicon through Roseta 2).

This bumping may fixes:

 * #559 
 * #205 #376 #538 
 * #556 