### PR TITLE
Add development branch note

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,6 +26,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
+<!-- !!!!! If you are using a build from the development branch, please instead include the commit hash you are on -->
  * YTMDesktop version: ***vx.x.x***
  * OS: ***Windows*** or ***Linux*** or ***Mac***
  * OS version: ***X***


### PR DESCRIPTION
I've noticed some people making issues saying 1.14.0 even though it hasn't been released yet, and I assume their using the development branch.

I'm making this pull request to add a comment in the bug report template that tells the user to include the commit hash of the build they're on to make it easier for us to pin point issues