### PR TITLE
Disable disk caching option

### DIFF
--- a/main.js
+++ b/main.js
@@ -106,6 +106,8 @@ app.commandLine.appendSwitch('disable-features', 'MediaSessionService') //This k
 if (!app.isDefaultProtocolClient('ytmd', process.execPath)) {
     app.setAsDefaultProtocolClient('ytmd', process.execPath)
 }
+
+app.commandLine.appendSwitch('disable-http-cache')
     
 createCustomAppDir()
 


### PR DESCRIPTION
Chromium / electron seem to write all streamed media to disk needlessly by default, this PR seeks to disable that.

By way of comparison these are stats from launching, searching and playing the first 3 mins of a video:-

Caching on:-

![image](https://user-images.githubusercontent.com/965926/112521837-ddc0ac00-8d94-11eb-899d-16366e1be450.png)

Caching Off :-

![image](https://user-images.githubusercontent.com/965926/112515669-60923880-8d8e-11eb-9b00-ed3f1565da8b.png)

if you listen to music continuously during the work day this is over 4GB of unnecessary writes.

A similar flag was added to chrome to reduce battery usage caused by constant disk writes specifically for streaming media - so that should also be a pleasant side effect of this PR - though I won't claim to have proof.
