### PR TITLE
Fix infoPlayerProvider artist and album info

### DIFF
--- a/src/providers/infoPlayerProvider.js
+++ b/src/providers/infoPlayerProvider.js
@@ -223,17 +223,14 @@ function getAlbum(webContents) {
         .executeJavaScript(
             `
             var album = '';
-            var player_bar = document.getElementsByClassName("byline ytmusic-player-bar")[0].children;
-            var arr_player_bar = Array.from(player_bar);
+            var artist_album_and_year = document.getElementsByClassName('subtitle ytmusic-player-bar')[0].textContent;
+            var split_by_dot = artist_album_and_year.split(" • ");
             
-            arr_player_bar.forEach( function(data, index) {
-            
-            if (data.getAttribute('href') != null && data.getAttribute('href').includes('browse')) {
-                album = data.innerText;
-            }
-            } )
-            
-            album
+            // Ensure that we actually have album data set
+            if (split_by_dot.length > 1) {
+                album = split_by_dot[1];
+            }            
+            album;
             `
         )
         .then((album) => {

--- a/src/providers/infoPlayerProvider.js
+++ b/src/providers/infoPlayerProvider.js
@@ -201,14 +201,10 @@ function getAuthor(webContents) {
     webContents
         .executeJavaScript(
             `
-            var bar = document.getElementsByClassName('subtitle ytmusic-player-bar')[0];
-                        
-            if (bar.getElementsByClassName('yt-simple-endpoint yt-formatted-string')[0]) {
-            title = bar.getElementsByClassName('yt-simple-endpoint yt-formatted-string')[0].textContent;
-            } else if (bar.getElementsByClassName('byline ytmusic-player-bar')[0]) {
-            title = bar.getElementsByClassName('byline ytmusic-player-bar')[0].textContent;
-            }
-            title;
+            var title = '';
+            var artist_album_and_year = document.getElementsByClassName('subtitle ytmusic-player-bar')[0].textContent;
+            var split_by_dot = artist_album_and_year.split(" • ");
+            title = split_by_dot[0].trim();
             `
         )
         .then((author) => {


### PR DESCRIPTION
Fixes #120 
On Windows 10 and with both 1.13 & building from latest development branch I noticed that tracks were being scrobbled to last.fm with incorrect info.

For a specific example,: when listening to the album "Haram" by Armand Hammer & The Alchemist, "Haram" was set as the artist name and the album name was not parsed at all (so it was defaulting to "_")

With these changes, the album & artist info is parsed from the bar in the middle at the bottom while a track is playing:
![YouTube_Music_Desktop_App_m5g4mVp0Eh](https://user-images.githubusercontent.com/48119280/112877146-1501c680-90cf-11eb-851c-1969b2a5a160.png)
![YouTube_Music_Desktop_App_Sod34Iplvo](https://user-images.githubusercontent.com/48119280/112878101-3616e700-90d0-11eb-80e4-2ee29e2937c2.png)

Two related things in one PR - I'll happily split it into two if that'd be preferred :)
