### PR TITLE
🐛 Fix continue where you left off

### DIFF
--- a/main.js
+++ b/main.js
@@ -612,6 +612,13 @@ async function createWindow() {
                                 )
                             }
                         })
+                        .catch(() => {
+                            // JavaScript errored, assume no session link found and default to current url
+                            settingsProvider.set(
+                                'window-url',
+                                view.webContents.getURL()
+                            )
+                        })
                 }
 
                 writeLog({ type: 'info', data: `Listen: ${title} - ${author}` })

--- a/main.js
+++ b/main.js
@@ -361,7 +361,6 @@ async function createWindow() {
             `)
         }
         initialized = true
-        settingsProvider.set('window-url', view.webContents.getURL())
         view.webContents.insertCSS(`
             /* width */
             ::-webkit-scrollbar {
@@ -584,6 +583,35 @@ async function createWindow() {
 
                         sleepTimer.mode = 'off'
                     }
+                }
+
+                /**
+                 * Update the saved url if settings-continue-where-left-of is enabled
+                 */
+                if (settingsProvider.get('settings-continue-where-left-of')) {
+                    view.webContents
+                        .executeJavaScript(
+                            `
+                        document.querySelector('.yt-uix-sessionlink').href;
+                    `
+                        )
+                        .then((result) => {
+                            if (result) {
+                                const url = new URL(result)
+                                // Hostname correction as the provided url is for youtube.com
+                                url.hostname = 'music.youtube.com'
+                                settingsProvider.set(
+                                    'window-url',
+                                    url.toString()
+                                )
+                            } else {
+                                // No session link found so just default to the current url
+                                settingsProvider.set(
+                                    'window-url',
+                                    view.webContents.getURL()
+                                )
+                            }
+                        })
                 }
 
                 writeLog({ type: 'info', data: `Listen: ${title} - ${author}` })


### PR DESCRIPTION
Related to #740

Fixes the continue where you left off setting where it couldn't correctly save the queue. YouTube Music exposes an element that provides the session link for the currently playing song and playlist together so instead of using the window URL as it previously was, it will use that. Do note I made it so if session link isn't found it will default to the behavior it was doing before which is saving the current window URL.

Known issues:
-  Radio and autoplay queues aren't saved. This is upstream to YouTube Music and cannot be fixed.