### PR TITLE
:bug: Fixes U2F Devices on Snap

### DIFF
--- a/electron-builder-deploy64.yml
+++ b/electron-builder-deploy64.yml
@@ -49,3 +49,6 @@ linux:
 snap:
   slots: 
     - mpris
+  plugs:
+    - default
+    - u2f-devices


### PR DESCRIPTION
I'm not sure what it would take to auto-enable this, but this allows for users to use yubikeys etc to login after they connect the interface manually via
```
sudo snap connect youtube-music-desktop-app:u2f-devices :u2f-devices
```
Also let me know if it should go in the other builder config files, I am not sure what each of their purposes are and this was the only one with any snap specific configuration.

Fixes #110 