### PR TITLE
🔨 better flatpak intigrations

### DIFF
--- a/electron-builder-flatpak.yml
+++ b/electron-builder-flatpak.yml
@@ -1,0 +1,35 @@
+productName: YouTube Music Desktop App
+appId: app.ytmd
+
+files:
+  - '**/*'
+  - "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme}"
+  - "!**/node_modules/*/{test,__tests__,tests,powered-test,example,examples}"
+  - "!**/node_modules/*.d.ts"
+  - "!**/node_modules/.bin"
+  - "!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}"
+  - "!**/._*"
+  - "!**/{.DS_Store,.git,.hg,.svn,CVS,RCS,SCCS,.gitignore,.gitattributes}"
+  - "!**/{__pycache__,thumbs.db,.flowconfig,.idea,.vs,.nyc_output}"
+  - "!**/{npm-debug.log,yarn.lock,.yarn-integrity,.yarn-metadata.json}"
+  - '!LICENSE.md'
+  - '!CODE_OF_CONDUCT.md'
+  - '!CONTRIBUTING.md'
+  - '!README.md'
+  - '!STORE_VARIABLES.md'
+  - '!.prettierrc.json'
+  - '!package.json'
+  - '!package-lock.json'
+  - '!.cache'
+  - '!app-update.yml'
+  - '!dev-app-update.yml'
+
+protocols:
+  name: YouTube Music Desktop
+  schemes: [ytmd]
+
+linux:
+  icon: src/assets/favicon.png
+  category: AudioVideo
+  target: 
+    - dir

--- a/main.js
+++ b/main.js
@@ -38,6 +38,8 @@ const mprisProvider = require('./src/providers/mprisProvider')
 /* Variables =========================================================================== */
 const defaultUrl = 'https://music.youtube.com'
 
+const isFlatpak = (process.platform === 'linux' && process.env.FLATPAK_HOST==='1')
+
 let mainWindow,
     view,
     miniplayer,
@@ -1739,7 +1741,7 @@ if (!gotTheLock) {
                 tray.updateImage(payload)
         })
 
-        if (!isDev) {
+        if (!isDev && isFlatpak===false) {
             updater.checkUpdate(mainWindow, view)
 
             setInterval(function () {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "build:win": "npx electron-builder --win --config electron-builder-deploy64.yml",
         "build:mac": "npx electron-builder --mac --config electron-builder-deploy64.yml",
         "build:lin": "npx electron-builder --linux --config electron-builder-deploy64.yml",
+        "build:flatpak":"npx electron-builder --linux --config electron-builder-flatpak.yml",
         "publish:win": "npx electron-builder --win -p always --config electron-builder64.yml",
         "publish:mac": "npx electron-builder --mac -p always --config electron-builder64.yml",
         "publish:lin": "npx electron-builder --linux -p always --config electron-builder64.yml"


### PR DESCRIPTION
The first commit disables auto updates when it detects it is running in a flatpak. This is detected by checking if the current platform is linux and the env var `FLATPAK_HOST` is 1.  The second commit adds the command `build:flatpak` to scripts. it simply produces a unpacked release build.