### PR TITLE
✨ Add Album to Rich Presences' Large Picture

### DIFF
--- a/src/providers/discordRpcProvider.js
+++ b/src/providers/discordRpcProvider.js
@@ -61,7 +61,8 @@ async function setActivity(info) {
             }
         }
 
-        activity.largeImageKey = 'ytm_logo_512'
+        // activity.largeImageKey = 'ytm_logo_512'
+        activity.largeImageKey = info.track.cover
         activity.smallImageKey = info.player.isPaused
             ? 'discordrpc-pause'
             : 'discordrpc-play'


### PR DESCRIPTION
Discord has finally added support of being able to use Custom Links within Rich Presences allowing for us to be able to display the Album Art of the current song in the Large image!
A Long awaited feature implemented. 😍

Large Profile:
![Large Profile](https://user-images.githubusercontent.com/17199186/147830472-57bc8537-c985-409f-bf17-9a4880d420d3.png)

Small profile:
![Small Profile](https://user-images.githubusercontent.com/17199186/147830485-414cbf4d-556b-4a82-b4bd-4192eecd2f1d.png)

