### PR TITLE
feat(discord): Use track cover in discord RPC

### DIFF
--- a/src/providers/discordRpcProvider.js
+++ b/src/providers/discordRpcProvider.js
@@ -63,7 +63,7 @@ function setActivity(info) {
             }
         }
 
-        activity.largeImageKey = 'ytm_logo_512'
+        activity.largeImageKey = info.track.cover
         activity.smallImageKey = info.player.isPaused
             ? 'discordrpc-pause'
             : 'discordrpc-play'


### PR DESCRIPTION
Discord announced today that rich presence now supports dynamic URL images. With this, it's possible to use the album art 🎉 

Looks like this:
![image](https://user-images.githubusercontent.com/17045274/151625681-0f4fc28c-b590-433d-8037-75cffbbbfab2.png)
