### PR TITLE
✨ Alternate Miniplayer Stream Widget

### DIFF
--- a/main.js
+++ b/main.js
@@ -1272,38 +1272,75 @@ async function createWindow() {
     async function windowMiniplayer() {
         if (miniplayer) miniplayer.show()
         else {
-            miniplayer = new BrowserWindow({
-                title: __.trans('LABEL_MINIPLAYER'),
-                icon: iconDefault,
-                modal: false,
-                frame: false,
-                center: false,
-                resizable: settingsProvider.get(
-                    'settings-miniplayer-resizable'
-                ),
-                alwaysOnTop: settingsProvider.get(
-                    'settings-miniplayer-always-top'
-                ),
-                width: settingsProvider.get('settings-miniplayer-size'),
-                height: settingsProvider.get('settings-miniplayer-size'),
-                backgroundColor: '#232323',
-                minWidth: 100,
-                minHeight: 100,
-                autoHideMenuBar: true,
-                skipTaskbar: !settingsProvider.get(
-                    'settings-miniplayer-show-task'
-                ),
-                webPreferences: {
-                    nodeIntegration: true,
-                    enableRemoteModule: true,
-                },
-            })
-            await miniplayer.loadFile(
-                path.join(
-                    app.getAppPath(),
-                    '/src/pages/miniplayer/miniplayer.html'
+            if (settingsProvider.get('settings-miniplayer-stream-config')) {
+                miniplayer = new BrowserWindow({
+                    title: __.trans('LABEL_MINIPLAYER'),
+                    icon: iconDefault,
+                    modal: false,
+                    frame: false,
+                    center: false,
+
+                    width: 500,
+                    height: 100,
+                    resizable: false,
+                    skipTaskbar: false,
+
+                    alwaysOnTop: settingsProvider.get(
+                        'settings-miniplayer-always-top'
+                    ),
+
+                    backgroundColor: '#232323',
+                    minWidth: 100,
+                    minHeight: 100,
+                    autoHideMenuBar: true,
+                    webPreferences: {
+                        nodeIntegration: true,
+                        enableRemoteModule: true,
+                    },
+                })
+            } else {
+                miniplayer = new BrowserWindow({
+                    title: __.trans('LABEL_MINIPLAYER'),
+                    icon: iconDefault,
+                    modal: false,
+                    frame: false,
+                    center: false,
+
+                    resizable: settingsProvider.get('settings-miniplayer-resizable'),
+                    skipTaskbar: !settingsProvider.get('settings-miniplayer-show-task'),
+                    width: settingsProvider.get('settings-miniplayer-size'),
+                    height: settingsProvider.get('settings-miniplayer-size'),
+
+                    alwaysOnTop: settingsProvider.get(
+                        'settings-miniplayer-always-top'
+                    ),
+
+                    backgroundColor: '#232323',
+                    minWidth: 100,
+                    minHeight: 100,
+                    autoHideMenuBar: true,
+                    webPreferences: {
+                        nodeIntegration: true,
+                        enableRemoteModule: true,
+                    },
+                })
+            }
+
+            if (!settingsProvider.get('settings-miniplayer-stream-config')) {
+                miniplayer.loadFile(
+                    path.join(
+                        app.getAppPath(),
+                        '/src/pages/miniplayer/miniplayer.html'
+                    )
                 )
-            )
+            } else {
+                miniplayer.loadFile(
+                    path.join(
+                        app.getAppPath(),
+                        '/src/pages/miniplayer/streamPlayer.html'
+                    )
+                )
+            }
 
             let miniplayerPosition = settingsProvider.get('miniplayer-position')
             if (miniplayerPosition !== undefined)
@@ -1326,13 +1363,15 @@ async function createWindow() {
             })
 
             miniplayer.on('resize', (e) => {
-                try {
-                    let size = Math.min(...miniplayer.getSize())
-                    miniplayer.setSize(size, size)
-                    settingsProvider.set('settings-miniplayer-size', size)
-                    e.preventDefault()
-                } catch (_) {
-                    writeLog({ type: 'warn', data: 'error miniplayer resize' })
+                if (!settingsProvider.get('settings-miniplayer-stream-config')) {
+                    try {
+                        let size = Math.min(...miniplayer.getSize())
+                        miniplayer.setSize(size, size)
+                        settingsProvider.set('settings-miniplayer-size', size)
+                        e.preventDefault()
+                    } catch (_) {
+                        writeLog({ type: 'warn', data: 'error miniplayer resize' })
+                    }
                 }
             })
 

--- a/main.js
+++ b/main.js
@@ -1327,14 +1327,14 @@ async function createWindow() {
             }
 
             if (!settingsProvider.get('settings-miniplayer-stream-config')) {
-                miniplayer.loadFile(
+                await miniplayer.loadFile(
                     path.join(
                         app.getAppPath(),
                         '/src/pages/miniplayer/miniplayer.html'
                     )
                 )
             } else {
-                miniplayer.loadFile(
+                await miniplayer.loadFile(
                     path.join(
                         app.getAppPath(),
                         '/src/pages/miniplayer/streamPlayer.html'

--- a/src/pages/miniplayer/miniplayer.css
+++ b/src/pages/miniplayer/miniplayer.css
@@ -52,6 +52,24 @@ body.showinfo #background {
     margin-top: calc(10vmin - 4px);
 }
 
+/*
+    Album is a data call used in the stream player but not in the default.
+    Due to the .js file calling this data I maintain parity with these base files.
+    I have set the opacity to 0 and the position to absolute to not interfere.
+    Just get rid of those settings to add it to the default mini player.
+*/
+.album {
+    opacity: 0;
+    position: absolute;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+    white-space: nowrap;
+    font-size: 18vmin;
+    margin-top: -6vmin;
+    margin-left: 22.5vmax;
+}
+
 .author {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/pages/miniplayer/miniplayer.html
+++ b/src/pages/miniplayer/miniplayer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -50,6 +50,10 @@
         <div class="player-info">
             <div class="title center">
                 <span id="title">Title</span>
+            </div>
+
+            <div class="album center">
+                <span id="album">Album</span>
             </div>
 
             <div class="author center">

--- a/src/pages/miniplayer/miniplayer.js
+++ b/src/pages/miniplayer/miniplayer.js
@@ -12,6 +12,7 @@ let body = document.getElementsByTagName('body')[0]
 let background = document.getElementById('background')
 let title = document.getElementById('title')
 let author = document.getElementById('author')
+let album = document.getElementById('album')
 
 let current = document.getElementById('current')
 let duration = document.getElementById('duration')
@@ -86,6 +87,7 @@ function setPlayerInfo(data) {
     background.style.backgroundImage = `url(${data.track.cover})`
     title.innerHTML = data.track.title || 'Title'
     author.innerHTML = data.track.author || 'Author'
+    album.innerHTML = data.track.album || 'Album'
     current.innerHTML = data.player.seekbarCurrentPositionHuman || '0:00'
     duration.innerHTML = data.track.durationHuman || '0:00'
     progress.style.width = data.player.statePercent * 100 + '%'

--- a/src/pages/miniplayer/streamPlayer.css
+++ b/src/pages/miniplayer/streamPlayer.css
@@ -1,0 +1,136 @@
+body:hover .player-info,
+body:hover .cmd-btn,
+body.showinfo .player-info,
+body.showinfo .cmd-btn {
+    filter: none;
+}
+
+.player-info {
+    height: 78vmin;
+}
+
+.cmd-bar {
+    margin: 4px 4px 0;
+    height: 10vmin;
+}
+
+.cmd-btn {
+    width: 20px;
+    height: 20px;
+}
+
+.cmd-btn i {
+    font-size: 12vmin;
+    margin-right: -1vmin;
+}
+
+#btn-drag {
+    opacity: 0;
+}
+
+#btn-like,
+#btn-dislike,
+#btn-next,
+#btn-previous,
+#btn-play-pause {
+    margin-top: 100vmax;
+    opacity: 0;
+}
+
+.title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+    white-space: nowrap;
+    font-weight: bold;
+    font-size: 22vmin;
+    margin-top: -13vmin;
+    margin-left: 22.5vmax;
+}
+
+.album {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+    white-space: nowrap;
+    font-size: 18vmin;
+    margin-top: -6vmin;
+    margin-left: 22.5vmax;
+}
+
+.author {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+    white-space: nowrap;
+    font-size: 16vmin;
+    margin-top: -5vmin;
+    margin-left: 22.5vmax;
+}
+
+.duration {
+    text-align: left;
+    font-size: 14vmin;
+    margin-top: -4vmin;
+    margin-left: 22.5vmax;
+}
+
+.progress-bar {
+    margin-top: 15vmin;
+    height: 5vmin;
+    width: 80vmax;
+    margin-left: 20vmax;
+}
+
+#progress {
+    height: 100%;
+    width: 0;
+    background: #fff;
+}
+
+#content,
+#secondsEffect {
+    position: absolute;
+    top: 0;
+    width: 100vmax;
+    height: 100vmin;
+    z-index: 1;
+}
+
+#content {
+    text-shadow: 0 0 3 #000;
+}
+
+#background {
+    background-repeat: no-repeat;
+    background-size: 100px 100px;
+    background-position: center;
+    position: absolute;
+    width: 100vmin;
+    height: 100vmin;
+    z-index: 0;
+}
+
+#loading {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    z-index: 1;
+}
+
+#secondsEffect {
+    display: none;
+}
+
+#secondsEffect.left {
+    left: -40vmin;
+    display: block;
+}
+
+#secondsEffect.right {
+    right: -40vmin;
+    transform: rotate(180deg);
+    display: block;
+}

--- a/src/pages/miniplayer/streamPlayer.css
+++ b/src/pages/miniplayer/streamPlayer.css
@@ -1,3 +1,7 @@
+:root {
+    --text-margin-left: 12px;
+}
+
 body:hover .player-info,
 body:hover .cmd-btn,
 body.showinfo .player-info,
@@ -6,12 +10,16 @@ body.showinfo .cmd-btn {
 }
 
 .player-info {
-    height: 78vmin;
+    height: 100vh;
+    margin-top: 10vh;
 }
 
 .cmd-bar {
     margin: 4px 4px 0;
-    height: 10vmin;
+    height: 100vh;
+    position: absolute;
+    top: 0;
+    width: calc(100% - 8px);
 }
 
 .cmd-btn {
@@ -45,7 +53,7 @@ body.showinfo .cmd-btn {
     font-weight: bold;
     font-size: 22vmin;
     margin-top: -13vmin;
-    margin-left: 22.5vmax;
+    margin-left: calc(100vh + var(--text-margin-left));
 }
 
 .album {
@@ -55,7 +63,7 @@ body.showinfo .cmd-btn {
     white-space: nowrap;
     font-size: 18vmin;
     margin-top: -6vmin;
-    margin-left: 22.5vmax;
+    margin-left: calc(100vh + var(--text-margin-left));
 }
 
 .author {
@@ -65,21 +73,23 @@ body.showinfo .cmd-btn {
     white-space: nowrap;
     font-size: 16vmin;
     margin-top: -5vmin;
-    margin-left: 22.5vmax;
+    margin-left: calc(100vh + var(--text-margin-left));
 }
 
 .duration {
     text-align: left;
     font-size: 14vmin;
     margin-top: -4vmin;
-    margin-left: 22.5vmax;
+    margin-left: calc(100vh + var(--text-margin-left));
 }
 
 .progress-bar {
     margin-top: 15vmin;
     height: 5vmin;
     width: 80vmax;
-    margin-left: 20vmax;
+    margin-left: calc(100vh);
+    position: absolute;
+    bottom: 0;
 }
 
 #progress {
@@ -103,11 +113,11 @@ body.showinfo .cmd-btn {
 
 #background {
     background-repeat: no-repeat;
-    background-size: 100px 100px;
+    background-size: 100vh 100vh;
     background-position: center;
     position: absolute;
-    width: 100vmin;
-    height: 100vmin;
+    width: 100vh;
+    height: 100vh;
     z-index: 0;
 }
 

--- a/src/pages/miniplayer/streamPlayer.html
+++ b/src/pages/miniplayer/streamPlayer.html
@@ -50,11 +50,11 @@
                 <div class="title center">
                     <span id="title">Title</span>
                 </div>
-                
+
                 <div class="album center">
                     <span id="album">Album</span>
                 </div>
-                
+
                 <div class="author center">
                     <span id="author">Author</span>
                 </div>
@@ -64,6 +64,7 @@
                     <span id="duration">0:00</span>
                 </div>
 
+                <!-- These are unused however are left in here for the Mini-player to be happy without needing to re-write it. -->
                 <div class="controls">
                     <div class="pointer ctrl-btn" id="btn-dislike">
                         <i class="material-icons outlined">thumb_down</i>

--- a/src/pages/miniplayer/streamPlayer.html
+++ b/src/pages/miniplayer/streamPlayer.html
@@ -1,0 +1,95 @@
+﻿<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>YouTube Music</title>
+        <link
+            type="text/css"
+            rel="stylesheet"
+            href="../../../src/assets/css/materialize.min.css"
+            media="screen,projection"
+        />
+        <link
+            href="../../../src/assets/css/material_icons.css"
+            rel="stylesheet"
+        />
+        <link
+            type="text/css"
+            rel="stylesheet"
+            href="../../../src/assets/css/styles.css"
+        />
+        <link type="text/css" rel="stylesheet" href="./streamPlayer.css" />
+    </head>
+
+    <body>
+        <div id="loading">
+            <div class="preloader-wrapper big active">
+                <div class="spinner-layer spinner-red-only">
+                    <div class="circle-clipper left">
+                        <div class="circle"></div>
+                    </div>
+                    <div class="gap-patch">
+                        <div class="circle"></div>
+                    </div>
+                    <div class="circle-clipper right">
+                        <div class="circle"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div id="content" class="hide">
+            <div class="cmd-bar drag">
+                <div class="cmd-btn left drag" id="btn-drag">
+                    <i class="material-icons">drag_indicator</i>
+                </div>
+                <div class="pointer cmd-btn right no-drag" id="btn-close">
+                    <i class="material-icons">launch</i>
+                </div>
+            </div>
+
+            <div class="player-info">
+                <div class="title center">
+                    <span id="title">Title</span>
+                </div>
+                
+                <div class="album center">
+                    <span id="album">Album</span>
+                </div>
+                
+                <div class="author center">
+                    <span id="author">Author</span>
+                </div>
+
+                <div class="duration center">
+                    <span id="current">0:00</span> /
+                    <span id="duration">0:00</span>
+                </div>
+
+                <div class="controls">
+                    <div class="pointer ctrl-btn" id="btn-dislike">
+                        <i class="material-icons outlined">thumb_down</i>
+                    </div>
+                    <div class="pointer ctrl-btn" id="btn-previous">
+                        <i class="material-icons">skip_previous</i>
+                    </div>
+                    <div class="pointer ctrl-btn" id="btn-play-pause">
+                        <i class="material-icons">play_arrow</i>
+                    </div>
+                    <div class="pointer ctrl-btn" id="btn-next">
+                        <i class="material-icons">skip_next</i>
+                    </div>
+                    <div class="pointer ctrl-btn" id="btn-like">
+                        <i class="material-icons outlined">thumb_up</i>
+                    </div>
+                </div>
+            </div>
+            <div class="progress-bar">
+                <div id="progress"></div>
+            </div>
+        </div>
+
+        <div id="background"></div>
+        <div id="secondsEffect"></div>
+    </body>
+
+    <script src="./miniplayer.js"></script>
+</html>

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -259,3 +259,26 @@ input[type=range]+.thumb {
 .icon-normalize {
     margin-top: 12px;
 }
+
+.tooltip {
+    position: relative;
+    display: inline-block;
+    line-height: 15px;
+    font-size: 14px;
+}
+
+.tooltip .tooltiptext {
+    position: absolute;
+    width: 200px;
+    margin-left: 5px;
+    visibility: hidden;
+    background-color: dimgray;
+    color: black;
+    fill: dimgray;
+    border-radius: 10px;
+    padding: 5px 5px;
+}
+
+.tooltip:hover .tooltiptext {
+    visibility: visible;
+}

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -674,17 +674,27 @@
                                     </tr>
                                     <tr>
                                         <td>
-                                            <span i18n="i18n_LABEL_SETTINGS_TAB_MINIPLAYER_STREAM_CONFIG"></span>
+                                            <span
+                                                i18n="i18n_LABEL_SETTINGS_TAB_MINIPLAYER_STREAM_CONFIG"
+                                            ></span>
                                             <sub class="tooltip">
-                                                <i class="material-icons tiny grey-text">info</i>
-                                                <span class="tooltiptext">Changes the layout of the miniplayer, optimizing screen space for easy use with live streaming.  The following settings will be ignored: miniplayer size, resizability, and taskbar visibility.</span>
+                                                <i
+                                                    class="material-icons tiny grey-text"
+                                                    >info</i
+                                                >
+                                                <span
+                                                    class="tooltiptext"
+                                                    i18n="i18n_LABEL_SETTINGS_TAB_MINIPLAYER_STREAM_CONFIG_TOOLTIP"
+                                                ></span>
                                             </sub>
                                         </td>
                                         <td class="right">
                                             <div class="switch">
                                                 <label>
-                                                    <input type="checkbox"
-                                                           id="settings-miniplayer-stream-config" />
+                                                    <input
+                                                        type="checkbox"
+                                                        id="settings-miniplayer-stream-config"
+                                                    />
                                                     <span class="lever"></span>
                                                 </label>
                                             </div>

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
@@ -667,6 +667,24 @@
                                                         type="checkbox"
                                                         id="settings-miniplayer-show-task"
                                                     />
+                                                    <span class="lever"></span>
+                                                </label>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <span i18n="i18n_LABEL_SETTINGS_TAB_MINIPLAYER_STREAM_CONFIG"></span>
+                                            <sub class="tooltip">
+                                                <i class="material-icons tiny grey-text">info</i>
+                                                <span class="tooltiptext">Changes the layout of the miniplayer, optimizing screen space for easy use with live streaming.  The following settings will be ignored: miniplayer size, resizability, and taskbar visibility.</span>
+                                            </sub>
+                                        </td>
+                                        <td class="right">
+                                            <div class="switch">
+                                                <label>
+                                                    <input type="checkbox"
+                                                           id="settings-miniplayer-stream-config" />
                                                     <span class="lever"></span>
                                                 </label>
                                             </div>

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -220,6 +220,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initElement('settings-miniplayer-show-task', 'click', null)
     initElement('settings-miniplayer-always-show-controls', 'click', null)
     initElement('settings-miniplayer-paint-controls', 'click', null)
+    initElement('settings-miniplayer-stream-config', 'click', null)
     initElement('settings-enable-taskbar-progressbar', 'click', () => {
         ipc.send('refresh-progress')
     })

--- a/src/utils/defaultSettings.js
+++ b/src/utils/defaultSettings.js
@@ -23,6 +23,8 @@ settingsProvider.setInitialValue('settings-miniplayer-show-task', false) // hide
 
 settingsProvider.setInitialValue('settings-miniplayer-always-top', false) // show on top always
 
+settingsProvider.setInitialValue('settings-miniplayer-stream-config', false) // use base miniplayer
+
 settingsProvider.setInitialValue('settings-lyrics-provider', '1') // OVH
 
 settingsProvider.setInitialValue('settings-lyrics-always-top', false) // show on top always


### PR DESCRIPTION
ONCE MORE, WITH FEELING

Many "Now Playing" music widgets for use in OBS/XSplit usually require multiple third party services or software programs, and more often than not only have support for Spotify or web-hosted music streaming. Additionally, due to the information passing between multiple APIs it is common for the information displayed to not be accurate or sufficient. This feature is intended to be a baked-in solution for the YouTube Music Desktop Application, by shuffling around the existing elements of the Miniplayer for more optimized screen space and information display. I have added a toggle in the Miniplayer settings menu, which will load alternate HTML/CSS files that play nicely with these streaming tools, as well as a tooltip on the toggle to indicate to the user settings that this feature will ignore.

Alright, take two - Started from scratch, hopefully this should be better, localization PR to follow.