### PR TITLE
Update infoPlayerProvider.js - Fix images for queue not in api

### DIFF
--- a/src/providers/infoPlayerProvider.js
+++ b/src/providers/infoPlayerProvider.js
@@ -307,7 +307,7 @@ function getQueue(webContents) {
     webContents
         .executeJavaScript(
             `
-            var element = document.querySelector('ytmusic-player-queue #contents')
+            var element = document.querySelectorAll('ytmusic-player-queue #contents')[1]
             var children = element.children
 
             var arrChildren = Array.from(children)


### PR DESCRIPTION
Change the area from which the que list is grabbed. This new path will resolve the correct images once they have been previewed by the user. 
*A better way for this needs to be done because i don't really like the use of the "[1]"*