### PR TITLE
💚  Pin workflow macos build environment to `macos-11`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-2019]
+        os: [macos-11, ubuntu-latest, windows-2019]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Pin to macos-11 since mscos-12 don't have python2 which will cause build fail.