### PR TITLE
Added button for enable disable global shortcut

### DIFF
--- a/STORE_VARIABLES.md
+++ b/STORE_VARIABLES.md
@@ -38,6 +38,7 @@
 | `settings-volume-media-keys`               | Boolean | `true` or `false`            | `false`                      | Enable media volume keys for the playback volume                                     |
 | `settings-pause-on-suspend`                | Boolean | `true` or `false`            | `false`                      | Pause media playback on `suspend` event triggered                                    |
 | `settings-surround-sound`                  | Boolean | `true` or `false`            | `false`                      | Enable Chromium Flag "try-supported-channel-layouts" for surround sound/Speaker Fill |
+| `settings-enable-disable-media-control`    | Boolean | `true` or `false`            | `true`                      | Enable or Disable All Global Shortcut                                                 |
 
 ## Window
 | Key                                   | Type    | Values                       | Default                      | Description                                   |

--- a/main.js
+++ b/main.js
@@ -832,65 +832,85 @@ async function createWindow() {
         if (dataMain.type !== undefined) args = dataMain
         else args = dataRenderer
 
+        let globalShortcutButton = settingsProvider.get(
+            'settings-enable-disable-media-control'
+        )
+
         try {
             globalShortcut.unregister(args.oldValue)
         } catch (_) {}
 
         switch (args.type) {
             case 'media-play-pause':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['media-play-pause']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['media-play-pause']
+                    )
+                }
                 break
 
             case 'media-track-next':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['media-track-next']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['media-track-next']
+                    )
+                }
                 break
 
             case 'media-track-previous':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['media-track-previous']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['media-track-previous']
+                    )
+                }
                 break
 
             case 'media-track-like':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['media-track-like']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['media-track-like']
+                    )
+                }
                 break
 
             case 'media-track-dislike':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['media-track-dislike']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['media-track-dislike']
+                    )
+                }
                 break
 
             case 'media-volume-up':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['media-volume-up']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['media-volume-up']
+                    )
+                }
                 break
 
             case 'media-volume-down':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['media-volume-down']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['media-volume-down']
+                    )
+                }
                 break
 
             case 'miniplayer-open-close':
-                registerGlobalShortcut(
-                    args.newValue,
-                    acceleratorFnMap['miniplayer-open-close']
-                )
+                if (globalShortcutButton) {
+                    registerGlobalShortcut(
+                        args.newValue,
+                        acceleratorFnMap['miniplayer-open-close']
+                    )
+                }
                 break
             case 'media-control-enable-disable':
                 if (args.oldValue == 'enable' && args.newValue == 'disabled') {

--- a/main.js
+++ b/main.js
@@ -227,14 +227,20 @@ let acceleratorFnMap = {
     },
     'miniplayer-open-close': () => {
         try {
-            if (miniplayer) {
-                miniplayer.close()
-                miniplayer = undefined
-                mainWindow.show()
-            } else {
-                ipcMain.emit('window', {
-                    command: 'show-miniplayer',
-                })
+            let globalShortcutButton = settingsProvider.get(
+                'settings-enable-disable-media-control'
+            )
+
+            if (globalShortcutButton) {
+                if (miniplayer) {
+                    miniplayer.close()
+                    miniplayer = undefined
+                    mainWindow.show()
+                } else {
+                    ipcMain.emit('window', {
+                        command: 'show-miniplayer',
+                    })
+                }
             }
         } catch (_) {
             writeLog({

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -33,20 +33,11 @@
                                     href="#tab-general"
                                 >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                            hide
-                                        "
+                                        class="material-icons left icon-normalize hide"
                                         >dashboard</i
                                     >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                        "
+                                        class="material-icons left icon-normalize"
                                         >blur_on</i
                                     >
                                     <span
@@ -60,11 +51,7 @@
                                     href="#tab-appearance"
                                 >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                        "
+                                        class="material-icons left icon-normalize"
                                         >personal_video</i
                                     >
                                     <span
@@ -78,11 +65,7 @@
                                     href="#tab-playback"
                                 >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                        "
+                                        class="material-icons left icon-normalize"
                                         >music_note</i
                                     >
                                     <span
@@ -96,11 +79,7 @@
                                     href="#tab-miniplayer"
                                 >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                        "
+                                        class="material-icons left icon-normalize"
                                         >picture_in_picture_alt</i
                                     >
                                     <span
@@ -114,20 +93,11 @@
                                     href="#tab-integration"
                                 >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                        "
+                                        class="material-icons left icon-normalize"
                                         >wifi_tethering</i
                                     >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                            hide
-                                        "
+                                        class="material-icons left icon-normalize hide"
                                         >linear_scale</i
                                     >
                                     <span
@@ -141,11 +111,7 @@
                                     href="#tab-shortcut"
                                 >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                        "
+                                        class="material-icons left icon-normalize"
                                         >keyboard</i
                                     >
                                     <span
@@ -159,11 +125,7 @@
                                     href="#tab-about"
                                 >
                                     <i
-                                        class="
-                                            material-icons
-                                            left
-                                            icon-normalize
-                                        "
+                                        class="material-icons left icon-normalize"
                                         >info_outline</i
                                     >
                                     <span
@@ -297,11 +259,7 @@
                                             ></span>
                                             <sub>
                                                 <i
-                                                    class="
-                                                        material-icons
-                                                        tiny
-                                                        grey-text
-                                                    "
+                                                    class="material-icons tiny grey-text"
                                                     >autorenew</i
                                                 >
                                             </sub>
@@ -326,11 +284,7 @@
                                             ></span>
                                             <sub>
                                                 <i
-                                                    class="
-                                                        material-icons
-                                                        tiny
-                                                        grey-text
-                                                    "
+                                                    class="material-icons tiny grey-text"
                                                     >autorenew</i
                                                 >
                                             </sub>
@@ -417,20 +371,11 @@
                                                     id="settings-app-audio-output"
                                                 ></select>
                                                 <button
-                                                    class="
-                                                        waves-effect waves-light
-                                                        btn-flat
-                                                        white-text
-                                                        btn-tiny
-                                                    "
+                                                    class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                     id="btn-reload-audio-devices"
                                                 >
                                                     <i
-                                                        class="
-                                                            material-icons
-                                                            tiny
-                                                            grey-text
-                                                        "
+                                                        class="material-icons tiny grey-text"
                                                         >autorenew</i
                                                     >
                                                 </button>
@@ -613,11 +558,7 @@
                                             ></span>
                                             <sub>
                                                 <i
-                                                    class="
-                                                        material-icons
-                                                        tiny
-                                                        grey-text
-                                                    "
+                                                    class="material-icons tiny grey-text"
                                                     >autorenew</i
                                                 >
                                             </sub>
@@ -738,11 +679,7 @@
                                             ></span>
                                             <sub class="tooltip">
                                                 <i
-                                                    class="
-                                                        material-icons
-                                                        tiny
-                                                        grey-text
-                                                    "
+                                                    class="material-icons tiny grey-text"
                                                     >info</i
                                                 >
                                                 <span
@@ -849,12 +786,7 @@
                                         <td class="right">
                                             <div class="switch">
                                                 <button
-                                                    class="
-                                                        waves-effect waves-light
-                                                        btn-flat
-                                                        white-text
-                                                        btn-tiny
-                                                    "
+                                                    class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                     id="btn-editor-custom-css-page"
                                                 >
                                                     <i class="material-icons"
@@ -883,12 +815,7 @@
                                                 style="margin-right: 12px"
                                             >
                                                 <button
-                                                    class="
-                                                        waves-effect waves-light
-                                                        btn-flat
-                                                        white-text
-                                                        btn-tiny
-                                                    "
+                                                    class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                     id="btn-shortcut-buttons-setting"
                                                 >
                                                     <i class="material-icons"
@@ -918,12 +845,7 @@
                                                 i18n="i18n_LABEL_SETTINGS_TAB_GENERAL_COMPANION_SERVER"
                                             ></span>
                                             <button
-                                                class="
-                                                    waves-effect waves-light
-                                                    btn-flat
-                                                    white-text
-                                                    btn-tiny
-                                                "
+                                                class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                 id="btn-open-companion-server"
                                             >
                                                 <i class="material-icons tiny"
@@ -984,11 +906,7 @@
                                             ></span>
                                             <sub>
                                                 <i
-                                                    class="
-                                                        material-icons
-                                                        tiny
-                                                        grey-text
-                                                    "
+                                                    class="material-icons tiny grey-text"
                                                     >autorenew</i
                                                 >
                                             </sub>
@@ -997,12 +915,7 @@
                                         <td class="right">
                                             <div class="switch">
                                                 <button
-                                                    class="
-                                                        waves-effect waves-light
-                                                        btn-flat
-                                                        white-text
-                                                        btn-tiny
-                                                    "
+                                                    class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                     id="btn-discord-setting"
                                                 >
                                                     <i class="material-icons"
@@ -1067,12 +980,7 @@
                                         <td class="right">
                                             <div class="switch">
                                                 <button
-                                                    class="
-                                                        waves-effect waves-light
-                                                        btn-flat
-                                                        white-text
-                                                        btn-tiny
-                                                    "
+                                                    class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                     id="btn-last-fm-login"
                                                 >
                                                     <i class="material-icons"
@@ -1108,10 +1016,7 @@
                                         </td>
                                     </tr>
                                     <tr
-                                        class="
-                                            windows-specific
-                                            windows10-specific
-                                        "
+                                        class="windows-specific windows10-specific"
                                     >
                                         <td>
                                             <span
@@ -1119,11 +1024,7 @@
                                             ></span>
                                             <sub>
                                                 <i
-                                                    class="
-                                                        material-icons
-                                                        tiny
-                                                        grey-text
-                                                    "
+                                                    class="material-icons tiny grey-text"
                                                     >autorenew</i
                                                 >
                                             </sub>
@@ -1142,10 +1043,7 @@
                                     </tr>
                                     <tr
                                         id="windows-10-show-info"
-                                        class="
-                                            windows-specific
-                                            windows10-specific
-                                        "
+                                        class="windows-specific windows10-specific"
                                     >
                                         <td>
                                             <span
@@ -1156,11 +1054,7 @@
                                             ></span>
                                             <sub>
                                                 <i
-                                                    class="
-                                                        material-icons
-                                                        tiny
-                                                        grey-text
-                                                    "
+                                                    class="material-icons tiny grey-text"
                                                     >autorenew</i
                                                 >
                                             </sub>
@@ -1184,12 +1078,7 @@
                                                 i18n="i18n_LABEL_SETTINGS_TAB_GENERAL_GENIUS_LYRICS"
                                             ></span>
                                             <button
-                                                class="
-                                                    waves-effect waves-light
-                                                    btn-flat
-                                                    white-text
-                                                    btn-tiny
-                                                "
+                                                class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                 id="btn-open-genius-auth-server"
                                             >
                                                 <i class="material-icons tiny"
@@ -1216,12 +1105,7 @@
                                                 Software)</span
                                             >
                                             <a
-                                                class="
-                                                    waves-effect waves-light
-                                                    btn-flat
-                                                    white-text
-                                                    btn-tiny
-                                                "
+                                                class="waves-effect waves-light btn-flat white-text btn-tiny"
                                                 externalURL="https://github.com/topik/youtube-music-obs-widget"
                                             >
                                                 <i class="material-icons tiny"
@@ -1248,35 +1132,19 @@
                                 <div class="modal-footer black-text">
                                     <a
                                         id="disableAccelerator"
-                                        class="
-                                            modal-close
-                                            waves-effect waves-red
-                                            btn-flat btn-sm
-                                            red
-                                            left
-                                        "
+                                        class="modal-close waves-effect waves-red btn-flat btn-sm red left"
                                     >
                                         <span i18n="i18n_LABEL_DISABLE"></span>
                                     </a>
                                     <a
                                         id="cancelAccelerator"
-                                        class="
-                                            modal-close
-                                            waves-effect waves-red
-                                            btn-flat btn-sm
-                                            black-text
-                                        "
+                                        class="modal-close waves-effect waves-red btn-flat btn-sm black-text"
                                     >
                                         <span i18n="i18n_LABEL_CANCEL"></span>
                                     </a>
                                     <a
                                         id="saveAccelerator"
-                                        class="
-                                            modal-close
-                                            waves-effect waves-green
-                                            btn-flat btn-sm
-                                            black-text
-                                        "
+                                        class="modal-close waves-effect waves-green btn-flat btn-sm black-text"
                                     >
                                         <span i18n="i18n_LABEL_SAVE"></span>
                                     </a>
@@ -1287,6 +1155,46 @@
                                 <div class="col s12">
                                     <table class="table">
                                         <tbody>
+                                            <tr style="border-bottom: none">
+                                                <td>
+                                                    <b>
+                                                        <span
+                                                            i18n="i18n_MEDIA_CONTROL_ENABLE_DISABLE"
+                                                        ></span>
+                                                    </b>
+                                                </td>
+                                                <th>
+                                                    <div
+                                                        class="switch"
+                                                        style="display: inline"
+                                                    >
+                                                        <label>
+                                                            <input
+                                                                type="checkbox"
+                                                                id="settings-enable-disable-media-control"
+                                                            />
+                                                            <span
+                                                                class="lever"
+                                                            ></span>
+                                                        </label>
+                                                    </div>
+                                                </th>
+                                            </tr>
+                                            <tr style="border-bottom: none">
+                                                <td
+                                                    colspan="2"
+                                                    style="padding-top: 5px"
+                                                >
+                                                    <div
+                                                        class="divider"
+                                                        style="
+                                                            border-bottom: none;
+                                                        "
+                                                    >
+                                                        &nbsp;
+                                                    </div>
+                                                </td>
+                                            </tr>
                                             <tr>
                                                 <td>
                                                     <span
@@ -1297,25 +1205,13 @@
                                                     <button
                                                         id="btn-accelerator-media-play-pause"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_media-play-pause"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>
@@ -1324,25 +1220,50 @@
                                                         i18n="i18n_LABEL_ALSO"
                                                     ></span>
                                                     <a
-                                                        class="
-                                                            btn btn-small
-                                                            white
-                                                            black-text
-                                                            disable
-                                                            btn-normalize
-                                                        "
+                                                        class="btn btn-small white black-text disable btn-normalize"
                                                     >
                                                         <i
-                                                            class="
-                                                                material-icons
-                                                                media-icons
-                                                            "
+                                                            class="material-icons media-icons"
                                                             >play_arrow</i
                                                         >/<i
-                                                            class="
-                                                                material-icons
-                                                                media-icons
-                                                            "
+                                                            class="material-icons media-icons"
+                                                            >pause</i
+                                                        >
+                                                    </a>
+                                                </th>
+                                            </tr>
+                                            <tr>
+                                                <td>
+                                                    <span
+                                                        i18n="i18n_MEDIA_CONTROL_PLAY_PAUSE"
+                                                    ></span>
+                                                </td>
+                                                <th>
+                                                    <button
+                                                        id="btn-accelerator-media-play-pause"
+                                                        data-target="modalEditAccelerator"
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
+                                                    >
+                                                        <span
+                                                            id="settings-accelerators_media-play-pause"
+                                                        ></span>
+                                                        <i
+                                                            class="tiny material-icons left"
+                                                            >edit</i
+                                                        >
+                                                    </button>
+                                                    <span
+                                                        class="shortcut-text"
+                                                        i18n="i18n_LABEL_ALSO"
+                                                    ></span>
+                                                    <a
+                                                        class="btn btn-small white black-text disable btn-normalize"
+                                                    >
+                                                        <i
+                                                            class="material-icons media-icons"
+                                                            >play_arrow</i
+                                                        >/<i
+                                                            class="material-icons media-icons"
                                                             >pause</i
                                                         >
                                                     </a>
@@ -1358,25 +1279,13 @@
                                                     <button
                                                         id="btn-accelerator-media-track-next"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_media-track-next"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>
@@ -1385,19 +1294,10 @@
                                                         i18n="i18n_LABEL_ALSO"
                                                     ></span>
                                                     <a
-                                                        class="
-                                                            btn btn-small
-                                                            white
-                                                            black-text
-                                                            disable
-                                                            btn-normalize
-                                                        "
+                                                        class="btn btn-small white black-text disable btn-normalize"
                                                     >
                                                         <i
-                                                            class="
-                                                                material-icons
-                                                                media-icons
-                                                            "
+                                                            class="material-icons media-icons"
                                                             >skip_next</i
                                                         >
                                                     </a>
@@ -1413,25 +1313,13 @@
                                                     <button
                                                         id="btn-accelerator-media-track-previous"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_media-track-previous"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>
@@ -1440,19 +1328,10 @@
                                                         i18n="i18n_LABEL_ALSO"
                                                     ></span>
                                                     <a
-                                                        class="
-                                                            btn btn-small
-                                                            white
-                                                            black-text
-                                                            disable
-                                                            btn-normalize
-                                                        "
+                                                        class="btn btn-small white black-text disable btn-normalize"
                                                     >
                                                         <i
-                                                            class="
-                                                                material-icons
-                                                                media-icons
-                                                            "
+                                                            class="material-icons media-icons"
                                                             >skip_previous</i
                                                         >
                                                     </a>
@@ -1468,25 +1347,13 @@
                                                     <button
                                                         id="btn-accelerator-media-track-like"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_media-track-like"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>
@@ -1502,25 +1369,13 @@
                                                     <button
                                                         id="btn-accelerator-media-track-dislike"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_media-track-dislike"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>
@@ -1536,25 +1391,13 @@
                                                     <button
                                                         id="btn-accelerator-media-volume-up"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_media-volume-up"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>
@@ -1570,25 +1413,13 @@
                                                     <button
                                                         id="btn-accelerator-media-volume-down"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_media-volume-down"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>
@@ -1627,25 +1458,13 @@
                                                     <button
                                                         id="btn-accelerator-miniplayer-open-close"
                                                         data-target="modalEditAccelerator"
-                                                        class="
-                                                            modal-trigger
-                                                            waves-effect
-                                                            waves-light
-                                                            btn-small
-                                                            text-initial
-                                                            black-text
-                                                            white
-                                                        "
+                                                        class="modal-trigger waves-effect waves-light btn-small text-initial black-text white"
                                                     >
                                                         <span
                                                             id="settings-accelerators_miniplayer-open-close"
                                                         ></span>
                                                         <i
-                                                            class="
-                                                                tiny
-                                                                material-icons
-                                                                left
-                                                            "
+                                                            class="tiny material-icons left"
                                                             >edit</i
                                                         >
                                                     </button>

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -522,6 +522,7 @@ function mInit() {
 }
 
 function replaceAcceleratorText(text) {
+    if (text === undefined) return text
     text = text.replace(/\+/g, ' + ')
 
     if (text.indexOf('CmdOrCtrl') !== -1)

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -151,6 +151,59 @@ checkCompanionStatus()
 checkClipboardWatcherStatus()
 checkWindows10ServiceStatus()
 
+function setMediaControllView(enableMediaControlKeys) {
+    let rootElement = document.querySelectorAll(
+        '#tab-shortcut > .row > .col > table > tbody > tr:nth-child(n+2)'
+    )
+    rootElement.forEach((row) => {
+        let labelMediaControl = row.querySelectorAll('td > span')
+        let actionMediaControl = row.querySelectorAll('th > *')
+        let switchMediaControl = row.querySelectorAll('th > div > label')
+
+        if (enableMediaControlKeys) {
+            labelMediaControl.forEach((label) => {
+                label.classList.remove('grey-text')
+                label.classList.remove('text-darken-3')
+            })
+
+            actionMediaControl.forEach((action) => {
+                action.classList.remove('grey-text')
+                action.classList.remove('text-darken-3')
+                action.classList.remove('disabled')
+            })
+
+            switchMediaControl.forEach((switchToggle) => {
+                switchToggle.firstElementChild.removeAttribute('disabled')
+                switchToggle.lastElementChild.classList.remove('grey')
+            })
+        } else {
+            labelMediaControl.forEach((label) => {
+                label.classList.add('grey-text')
+                label.classList.add('text-darken-3')
+            })
+
+            actionMediaControl.forEach((action) => {
+                action.classList.add('disabled')
+                action.classList.add('grey-text')
+                action.classList.add('text-darken-3')
+            })
+
+            switchMediaControl.forEach((switchToggle) => {
+                switchToggle.firstElementChild.setAttribute(
+                    'disabled',
+                    'disabled'
+                )
+                switchToggle.lastElementChild.classList.add('grey')
+            })
+        }
+    })
+}
+
+let enableMediaControlKeys = settingsProvider.get(
+    'settings-enable-disable-media-control'
+)
+setMediaControllView(enableMediaControlKeys)
+
 document.addEventListener('DOMContentLoaded', () => {
     initElement('settings-keep-background', 'click', null)
     initElement('settings-show-notifications', 'click', null)
@@ -193,6 +246,19 @@ document.addEventListener('DOMContentLoaded', () => {
     })
     initElement('settings-rainmeter-web-now-playing', 'click', null)
     initElement('settings-enable-double-tapping-show-hide', 'click', null)
+    initElement('settings-enable-disable-media-control', 'click', () => {
+        let enableMediaControlKeys = settingsProvider.get(
+            'settings-enable-disable-media-control'
+        )
+
+        ipc.send('change-accelerator', {
+            type: 'media-control-enable-disable',
+            oldValue: enableMediaControlKeys ? 'disabled' : 'enable',
+            newValue: enableMediaControlKeys ? 'enable' : 'disabled',
+        })
+
+        setMediaControllView(enableMediaControlKeys)
+    })
     initElement('settings-volume-media-keys', 'click', () => {
         let enableVolumeMediaKeys = settingsProvider.get(
             'settings-volume-media-keys'

--- a/src/utils/defaultSettings.js
+++ b/src/utils/defaultSettings.js
@@ -46,6 +46,8 @@ settingsProvider.setInitialValue(
 
 settingsProvider.setInitialValue('settings-enable-taskbar-progressbar', true) // Yes
 
+settingsProvider.setInitialValue('settings-enable-disable-media-control', true)
+
 settingsProvider.setInitialValue('settings-accelerators', {
     'media-play-pause': 'CmdOrCtrl+Shift+Space',
     'media-track-next': 'CmdOrCtrl+Shift+PageUp',

--- a/src/utils/defaultSettings.js
+++ b/src/utils/defaultSettings.js
@@ -46,7 +46,7 @@ settingsProvider.setInitialValue(
 
 settingsProvider.setInitialValue('settings-enable-taskbar-progressbar', true) // Yes
 
-settingsProvider.setInitialValue('settings-enable-disable-media-control', true)
+settingsProvider.setInitialValue('settings-enable-disable-media-control', false)
 
 settingsProvider.setInitialValue('settings-accelerators', {
     'media-play-pause': 'CmdOrCtrl+Shift+Space',


### PR DESCRIPTION
# Description
add button to enable/disable global shortcut.

# Context Background
when I use YTM Dekstop, I often press the wrong button that triggers the shortcut, and it's very annoying

# Support locales
"MEDIA_CONTROL_ENABLE_DISABLE": "Enable/Disable Shortcut Media Control",
https://github.com/ytmdesktop/ytmdesktop-locales/pull/23

# Screenshot Result
![image](https://user-images.githubusercontent.com/24775167/212384797-e87019d1-c171-49fc-b633-283722638cf8.png)
![image](https://user-images.githubusercontent.com/24775167/212384867-3e23b872-e3f2-4ef7-96ad-cf36f75278ba.png)

# How Has This Been Tested
i tested the local dev build and checked the shortcut work as expected

