### PR TITLE
Remove user agent, allows Google Sign In with 2FA

### DIFF
--- a/main.js
+++ b/main.js
@@ -273,9 +273,7 @@ async function createWindow() {
             const newRequestHeaders = Object.assign(
                 {},
                 details.requestHeaders || {},
-                {
-                    'User-Agent': settingsProvider.get('user-agent'),
-                }
+                {}
             )
             callback({ requestHeaders: newRequestHeaders })
         }
@@ -1432,8 +1430,7 @@ async function createWindow() {
                 './src/pages/shared/window-buttons/window-buttons.html'
             ),
             {
-                search:
-                    'page=settings/sub/last-fm/last-fm-login&icon=music_note&hide=btn-minimize,btn-maximize&title=Last.FM Login',
+                search: 'page=settings/sub/last-fm/last-fm-login&icon=music_note&hide=btn-minimize,btn-maximize&title=Last.FM Login',
             }
         )
     }
@@ -1463,8 +1460,7 @@ async function createWindow() {
                 './src/pages/shared/window-buttons/window-buttons.html'
             ),
             {
-                search:
-                    'page=editor/editor&icon=color_lens&hide=btn-minimize,btn-maximize',
+                search: 'page=editor/editor&icon=color_lens&hide=btn-minimize,btn-maximize',
             }
         )
     }
@@ -1841,7 +1837,8 @@ async function createWindow() {
                 clipboardWatcher = ClipboardWatcher({
                     watchDelay: 1000,
                     onTextChange: (text) => {
-                        let regExp = /(https?:\/\/)(www.)?(music.youtube|youtube|youtu.be).*/
+                        let regExp =
+                            /(https?:\/\/)(www.)?(music.youtube|youtube|youtu.be).*/
                         let match = text.match(regExp)
                         if (match) {
                             let videoUrl = match[0]
@@ -1885,7 +1882,8 @@ async function createWindow() {
         if (videoUrl.includes('music.youtube'))
             await view.webContents.loadURL(videoUrl)
         else {
-            let regExpYoutube = /^.*(https?:\/\/)?(www.)?(music.youtube|youtube|youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=|\?v=)([^#&?]*).*/
+            let regExpYoutube =
+                /^.*(https?:\/\/)?(www.)?(music.youtube|youtube|youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=|\?v=)([^#&?]*).*/
             let match = videoUrl.match(regExpYoutube)
             await view.webContents.loadURL(
                 'https://music.youtube.com/watch?v=' + match[4]


### PR DESCRIPTION
Greetings

I just saw this project on a video and find out about this issue https://github.com/ytmdesktop/ytmdesktop/issues/866. 

As far as I see, the user agent is something that you want to keep, but I don't see why, so, I tested to remove it at all, Also I tested with 1.13 but I am not submitting a PR of that just to avoid merge conflicts in the future or maybe a 1.13.1 branch and release for this fix.

Anyway, I tested this, used npm start and I am able to log in, the 2FA will ask for a hardware key, but at the bottom of that, there's another option to choose your desired verification process, choose what you can use and sign in. 

I also saw on the issue that changing this might causes some troubles, but, with 1.13, I was not able to spot a problem, playback, shortcuts, lyrics, sysicon tray, all seems to works fine. Although, testing 1.14 (master) I encounter other issues that are not related with this change, maybe I'll post about it later. If there's something else that I must test or contribute something else to fix this, I'll keep in touch.

I hope this helps and brings back on track YTM development.