### PR TITLE
📝 Add ARM64 to Bug Report Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -62,6 +62,7 @@ body:
     options:
       - x64
       - x86
+      - ARM64
   validations:
     required: true
 - type: input


### PR DESCRIPTION
Now that ARM64 builds are available since [v2.0.0-rc.4](../releases/tag/v2.0.0-rc.4) (via #1169), it seems appropriate to add ARM64 to the architecture options in the bug report form. Thus, this PR adds ARM64 option to the bug report form.