### PR TITLE
🚑 Fix #1212 #1214 play/pause get double triggered

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
       - run: npm config set python python3.10
       - run: yarn --frozen-lockfile
       - run: node ./script/build-current-platform.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 12
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
+      - run: npm config set python python3.10
       - run: yarn --frozen-lockfile
       - run: node ./script/build-current-platform.js
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - run: yarn --frozen-lockfile
       - run: node ./script/build-current-platform.js
       - uses: actions/upload-artifact@v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "youtube-music-desktop-app",
-    "version": "1.14.2",
+    "version": "1.14.3",
     "description": "YouTube Music Desktop App",
     "main": "main.js",
     "scripts": {


### PR DESCRIPTION
* Bump version to 1.14.2
* Temperoraly disable the `playFirst` logic
* Pin build workflow to use python3.10 as a workaround to avoid compiling error