### PR TITLE
🐛  Fix undefined ReferenceError: open is not defined

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1208,7 +1208,7 @@ app.on("ready", async () => {
     await fs.access(firstRunPath, fs.constants.F_OK);
   } catch (_) {
     // This is the first run of the program
-    const firstRunTouch = await open(firstRunPath, "a");
+    const firstRunTouch = await fs.open(firstRunPath, "a");
     await firstRunTouch.close();
 
     const v1ConfigPath = path.join(app.getPath("userData"), "..", "youtube-music-desktop-app", "config.json");


### PR DESCRIPTION
As I was getting the below error:

```bash
ReferenceError: open is not defined
    at App.<anonymous> (/path/to/ytmd/.webpack/main/index.js:65175:31)
```

after analyzing the error I explicitly added the fs method call, which solved the problem.