### PR TITLE
:lipstick: Improve readability of companions table

### DIFF
--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -376,8 +376,8 @@ window.ytmd.handleUpdateDownloaded(() => {
               <tbody>
                 <tr v-for="authToken in companionServerAuthTokens" :key="authToken.appId">
                   <td class="companion">
-                    <strong>{{ authToken.appId }}</strong
-                    ><br />{{ authToken.appName }}
+                    <p class="name">{{ authToken.appName }}</p>
+                    <p class="id">{{ authToken.appId }}</p>
                   </td>
                   <td class="version">{{ authToken.appVersion }}</td>
                   <td class="controls">
@@ -785,8 +785,14 @@ window.ytmd.handleUpdateDownloaded(() => {
 }
 
 .authorized-companions-table tr .companion {
-  width: 75%;
+  width: 70%;
   word-wrap: break-word;
+  line-height: 0.5;
+}
+
+.authorized-companions-table tr .companion .id {
+  color: #969696;
+  font-size: 14px;
 }
 
 .authorized-companions-table tbody tr .version {

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -375,7 +375,10 @@ window.ytmd.handleUpdateDownloaded(() => {
               </thead>
               <tbody>
                 <tr v-for="authToken in companionServerAuthTokens" :key="authToken.appId">
-                  <td class="companion"><strong>{{ authToken.appId }}</strong><br>{{ authToken.appName }}</td>
+                  <td class="companion">
+                    <strong>{{ authToken.appId }}</strong
+                    ><br />{{ authToken.appName }}
+                  </td>
                   <td class="version">{{ authToken.appVersion }}</td>
                   <td class="controls">
                     <button @click="deleteCompanionAuthToken(authToken.appId)"><span class="material-symbols-outlined">delete</span></button>
@@ -781,12 +784,8 @@ window.ytmd.handleUpdateDownloaded(() => {
   table-layout: fixed;
 }
 
-.authorized-companions-table tbody tr .id {
-  word-wrap: break-word;
-}
-
-.authorized-companions-table tr .name {
-  width: 50%;
+.authorized-companions-table tr .companion {
+  width: 75%;
   word-wrap: break-word;
 }
 

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -368,16 +368,14 @@ window.ytmd.handleUpdateDownloaded(() => {
             <table class="authorized-companions-table">
               <thead>
                 <tr>
-                  <th class="id">ID</th>
-                  <th class="name">Name</th>
+                  <th class="companion">Companion</th>
                   <th class="version">Version</th>
                   <th class="controls"></th>
                 </tr>
               </thead>
               <tbody>
                 <tr v-for="authToken in companionServerAuthTokens" :key="authToken.appId">
-                  <td class="id">{{ authToken.appId }}</td>
-                  <td class="name">{{ authToken.appName }}</td>
+                  <td class="companion"><strong>{{ authToken.appId }}</strong><br>{{ authToken.appName }}</td>
                   <td class="version">{{ authToken.appVersion }}</td>
                   <td class="controls">
                     <button @click="deleteCompanionAuthToken(authToken.appId)"><span class="material-symbols-outlined">delete</span></button>

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -376,8 +376,9 @@ window.ytmd.handleUpdateDownloaded(() => {
               <tbody>
                 <tr v-for="authToken in companionServerAuthTokens" :key="authToken.appId">
                   <td class="companion">
-                    <span class="name">{{ authToken.appName }}iuahs dhas uidhas uidhuais dhuiash duiasyhd iuashdui ahsdiuahsd asd uhi</span><br />
-                    <span class="id">{{ authToken.appId }}iuahs dhas uidhas uidhuais dhuiash duiasyhd iuashdui ahsdiuahsd asd uhi</span>
+                    <span class="name">{{ authToken.appName }}</span
+                    ><br />
+                    <span class="id">{{ authToken.appId }}</span>
                   </td>
                   <td class="version">{{ authToken.appVersion }}</td>
                   <td class="controls">

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -376,8 +376,8 @@ window.ytmd.handleUpdateDownloaded(() => {
               <tbody>
                 <tr v-for="authToken in companionServerAuthTokens" :key="authToken.appId">
                   <td class="companion">
-                    <p class="name">{{ authToken.appName }}</p>
-                    <p class="id">{{ authToken.appId }}</p>
+                    <span class="name">{{ authToken.appName }}iuahs dhas uidhas uidhuais dhuiash duiasyhd iuashdui ahsdiuahsd asd uhi</span><br />
+                    <span class="id">{{ authToken.appId }}iuahs dhas uidhas uidhuais dhuiash duiasyhd iuashdui ahsdiuahsd asd uhi</span>
                   </td>
                   <td class="version">{{ authToken.appVersion }}</td>
                   <td class="controls">
@@ -787,7 +787,6 @@ window.ytmd.handleUpdateDownloaded(() => {
 .authorized-companions-table tr .companion {
   width: 70%;
   word-wrap: break-word;
-  line-height: 0.5;
 }
 
 .authorized-companions-table tr .companion .id {


### PR DESCRIPTION
# What does this PR do?
This Pull Request improves readability of the companions table.

# How does it achieve the improvement?
Instead of squishing everything into 3 columns, reduce it to 2 columns and have id and name in the same `Companion` Column. This probably also improves word-wrap issues, because the id and name can now span across the row and due to the character limit, it won't wrap so extremely anymore or not not even at all.

And to better distinguish between the id and name, I made the id bold.

# How does it look like?
## Before
![image](https://github.com/ytmdesktop/ytmdesktop/assets/10864620/0362b7f4-638f-4b6c-8d76-bd9e50d05fb6)
## After
![image](https://github.com/ytmdesktop/ytmdesktop/assets/10864620/3aad1162-43ec-4ace-8855-ebb145180f22)
