### PR TITLE
Add Discord rich presence status display option

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -368,6 +368,7 @@ const store = new Conf<StoreSchema>({
       companionServerAuthTokens: null,
       companionServerCORSWildcardEnabled: false,
       discordPresenceEnabled: false,
+      discordPresenceStatusDisplayType: 1,
       lastFMEnabled: false
     },
     shortcuts: {
@@ -527,7 +528,7 @@ store.onDidAnyChange(async (newState, oldState) => {
   }
 
   if (newState.integrations.discordPresenceEnabled) {
-    discordPresence.provide(memoryStore);
+    discordPresence.provide(store, memoryStore);
   }
   if (newState.integrations.discordPresenceEnabled && !oldState.integrations.discordPresenceEnabled) {
     discordPresence.enable();
@@ -1941,7 +1942,7 @@ app.on("ready", async () => {
 
   // DiscordPresence
   if (store.get("integrations").discordPresenceEnabled) {
-    discordPresence.provide(memoryStore);
+    discordPresence.provide(store, memoryStore);
     discordPresence.enable();
     log.info("Integration enabled: Discord presence");
   }

--- a/src/main/integrations/discord-presence/index.ts
+++ b/src/main/integrations/discord-presence/index.ts
@@ -1,10 +1,11 @@
+import Conf from "conf";
 import playerStateStore, { PlayerState, Thumbnail, VideoDetails, VideoState } from "../../player-state-store";
 import IIntegration from "../integration";
 import MemoryStore from "../../memory-store";
-import { MemoryStoreSchema } from "~shared/store/schema";
+import { MemoryStoreSchema, StoreSchema } from "~shared/store/schema";
 import DiscordClient from "./minimal-discord-client";
 import log from "electron-log";
-import { DiscordActivityType } from "./minimal-discord-client/types";
+import { DiscordActivityType, DiscordActivityStatusDisplayType } from "./minimal-discord-client/types";
 
 const DISCORD_CLIENT_ID = "1143202598460076053";
 
@@ -50,6 +51,7 @@ function stringLimit(str: string, limit: number, minimum: number) {
 }
 
 export default class DiscordPresence implements IIntegration {
+  private store: Conf<StoreSchema>;
   private memoryStore: MemoryStore<MemoryStoreSchema>;
 
   private discordClient: DiscordClient = null;
@@ -77,7 +79,7 @@ export default class DiscordPresence implements IIntegration {
       const thumbnail = getHighestResThumbnail(thumbnails);
       this.discordClient.setActivity({
         type: DiscordActivityType.Listening,
-        status_display_type: 1,
+        status_display_type: this.store.get("integrations").discordPresenceStatusDisplayType ?? DiscordActivityStatusDisplayType.State,
         details: stringLimit(title, 128, 2),
         details_url: `https://music.youtube.com/watch?v=${id}`,
         state: stringLimit(author, 128, 2),
@@ -136,7 +138,8 @@ export default class DiscordPresence implements IIntegration {
     }, 30 * 1000);
   }
 
-  public provide(memoryStore: MemoryStore<MemoryStoreSchema>): void {
+  public provide(store: Conf<StoreSchema>, memoryStore: MemoryStore<MemoryStoreSchema>): void {
+    this.store = store;
     this.memoryStore = memoryStore;
   }
 

--- a/src/renderer/components/YTMDSetting.vue
+++ b/src/renderer/components/YTMDSetting.vue
@@ -319,7 +319,7 @@ input[type="range"]::-webkit-slider-thumb {
   position: absolute;
   left: 0;
   right: 0;
-  z-index: 1;
+  z-index: 3;
   border-radius: 0 0 4px 4px;
   width: 100%;
 }

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -60,6 +60,7 @@ const companionServerAuthTokens = ref<AuthToken[]>(
 );
 const companionServerCORSWildcardEnabled = ref<boolean>(integrations.companionServerCORSWildcardEnabled);
 const discordPresenceEnabled = ref<boolean>(integrations.discordPresenceEnabled);
+const discordPresenceStatusDisplayType = ref<number>(integrations.discordPresenceStatusDisplayType ?? 1);
 const lastFMEnabled = ref<boolean>(integrations.lastFMEnabled);
 
 const shortcutPlayPause = ref<string>(shortcuts.playPause);
@@ -98,6 +99,7 @@ store.onDidAnyChange(async newState => {
     : [];
   companionServerCORSWildcardEnabled.value = newState.integrations.companionServerCORSWildcardEnabled;
   discordPresenceEnabled.value = newState.integrations.discordPresenceEnabled;
+  discordPresenceStatusDisplayType.value = newState.integrations.discordPresenceStatusDisplayType ?? 1;
   lastFMEnabled.value = newState.integrations.lastFMEnabled;
   lastFMSessionKey.value = newState.lastfm.sessionKey;
   scrobblePercent.value = newState.lastfm.scrobblePercent;
@@ -168,6 +170,7 @@ async function settingsChanged() {
   store.set("integrations.companionServerEnabled", companionServerEnabled.value);
   store.set("integrations.companionServerCORSWildcardEnabled", companionServerCORSWildcardEnabled.value);
   store.set("integrations.discordPresenceEnabled", discordPresenceEnabled.value);
+  store.set("integrations.discordPresenceStatusDisplayType", discordPresenceStatusDisplayType.value);
   store.set("integrations.lastFMEnabled", lastFMEnabled.value);
   store.set("lastfm.scrobblePercent", scrobblePercent.value);
 
@@ -403,6 +406,15 @@ window.ytmd.handleUpdateDownloaded(() => {
             </div>
           </YTMDSetting>
           <YTMDSetting v-model="discordPresenceEnabled" type="checkbox" name="Discord rich presence" @change="settingsChanged" />
+          <YTMDSetting
+            v-if="discordPresenceEnabled"
+            v-model="discordPresenceStatusDisplayType"
+            :options-map="{ 0: 'Activity Name', 1: 'Artist Name', 2: 'Song Title' }"
+            type="select"
+            indented
+            name="Pick status display"
+            @change="settingsChanged"
+          />
           <div v-if="discordPresenceEnabled && discordPresenceConnectionFailed" class="setting indented">
             <p class="discord-failure">Discord connection could not be established after 30 attempts</p>
             <button @click="restartDiscordPresence">Retry</button>

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -34,6 +34,7 @@ export type StoreSchema = {
     companionServerAuthTokens: string | null; // array[object] | Encrypted for security
     companionServerCORSWildcardEnabled: boolean;
     discordPresenceEnabled: boolean;
+    discordPresenceStatusDisplayType: number;
     lastFMEnabled: boolean;
   };
   shortcuts: {


### PR DESCRIPTION
Adds an option to choose what the Discord rich presence shows as the status
line. 
Found under Settings -> Integrations -> Discord rich presence -> Pick status display.

The dropdown maps to Discord's `status_display_type`:

- Activity Name (0), shows "YouTube Music"
- Artist Name (1), the channel/author (default)
- Song Title (2), the track title

Defaults to Artist Name, so existing setups keep their current behavior unless
they change it.

<img width="799" height="592" alt="image" src="https://github.com/user-attachments/assets/995c2a6c-1187-40bf-9c07-b204bb4040fa" />