### PR TITLE
🐛 Stop the narrow-window side panel from covering the player bar

### DIFF
--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -82,6 +82,14 @@ function createStyleSheet() {
       .ytmd-player-bar-control.sleep-timer-button.active {
         color: #FFFFFF;
       }
+
+      /* Narrow windows put the player page into YouTube Music's mobile sheet layout, which sizes the
+         expanded side panel against the window bottom instead of the player bar, so the panel's
+         scrollbar is drawn over the player bar. */
+      ytmusic-player-page[is-mweb-modernization-enabled][player-page-ui-state="TABS_VIEW"] #side-panel.ytmusic-player-page {
+        height: auto;
+        bottom: var(--ytmusic-player-page-player-bar-height);
+      }
     `)
   );
   document.head.appendChild(css);


### PR DESCRIPTION
## The bug

When the window is narrow, the player page side panel's vertical scrollbar is drawn on top of the
player bar, covering its right end (the scrollbar's bottom arrow lands inside the player bar row).

## Root cause

Below a certain width YouTube Music switches the player page into its mobile sheet layout
(`ytmusic-player-page[is-mweb-modernization-enabled]`). In that layout `#side-panel` is
`position: fixed` and sized by YTM as:

```css
top: var(--ytmusic-player-page-player-bar-height);
height: calc(var(--ytmusic-player-page-inner-height) - var(--ytmusic-player-page-tabs-header-height));
```

With the sheet expanded (`player-page-ui-state="TABS_VIEW"`), that height makes the panel end at the
window bottom instead of at the player bar's top edge. The panel — and with it the scrollbar of the
`#tab-renderer` inside it — is therefore painted across the player bar.

Measured against a running app in a 460x820 window (viewport 460x784, player bar top at y=720):

| | `#side-panel` bottom | `#tab-renderer` bottom | overlap past the player bar |
| --- | --- | --- | --- |
| before | 780 | 780 | 60px |
| after | 720 | 720 | 0 |

## The fix

Let the fixed panel resolve its own height from `top`/`bottom` instead of the computed `height`, so
it ends exactly at the player bar. Scoped to the mobile sheet layout in its expanded state, added to
the stylesheet the app already injects into the YTM view.

## Verification

Driven over the DevTools protocol against the running app:

- **Deterministic.** Toggling the rule on and off three times in a single page session flips the
  overlap 60px <-> 0 every cycle, with the player bar and panel top held constant.
- **Inert when wide.** In a real 1865x1110 window every measured field is identical with the rule
  enabled and disabled (panel bottom 1002 = player bar top, overlap 0 either way).
- **Nothing is hidden.** The scrollbar is kept, not suppressed: the scrollbar gutter stays 15px and
  `scrollHeight > clientHeight` remains true before and after, so the tab content is still fully
  scrollable — only the panel's bounds change.
- **From the built package**, not just a live-injected rule: `yarn make` output measured at 460x820
  reports panel bottom 720, player bar top 720, overlap 0.

Note that emulated viewport resizing does not reproduce this — YTM drives the sheet layout from
JS-computed custom properties that only recompute on a real window resize, so all of the above was
measured with real window sizes.

## Notes

Related to #1784. This addresses the scrollbar-over-player-bar part of that report; I can't claim it
covers every symptom described there, so it is deliberately not marked as fixing it.

Environment: Linux (GNOME/Wayland), YTMDesktop 2.0.11, Electron 40.
