### PR TITLE
🐛 Stop scrollbars from being drawn across the player bar

### DIFF
--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -82,6 +82,14 @@ function createStyleSheet() {
       .ytmd-player-bar-control.sleep-timer-button.active {
         color: #FFFFFF;
       }
+
+      /* Narrow windows put the player page into YouTube Music's mobile sheet layout, which sizes the
+         expanded side panel against the window bottom instead of the player bar, so the panel's
+         scrollbar is drawn over the player bar. */
+      ytmusic-player-page[is-mweb-modernization-enabled][player-page-ui-state="TABS_VIEW"] #side-panel.ytmusic-player-page {
+        height: auto;
+        bottom: var(--ytmusic-player-page-player-bar-height);
+      }
     `)
   );
   document.head.appendChild(css);

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -90,6 +90,13 @@ function createStyleSheet() {
         height: auto;
         bottom: var(--ytmusic-player-page-player-bar-height);
       }
+
+      /* Browse pages scroll the document, so the classic scrollbar spans the whole window and runs
+         down the side of the fixed player bar, which then cannot reach the window edge. The wheel
+         and keyboard still scroll without it. Inner scrollers keep their own scrollbars. */
+      html {
+        scrollbar-width: none;
+      }
     `)
   );
   document.head.appendChild(css);


### PR DESCRIPTION
Two scrollbars end up drawn across the player bar. They have separate causes, so this is two small
CSS rules added to the stylesheet the app already injects into the YTM view.

Everything below was measured over the DevTools protocol against a running build, at real window
sizes. Emulated viewport resizing does **not** reproduce either one — YTM drives these layouts from
JS-computed custom properties that only recompute on a real window resize.

## 1. The expanded side panel runs past the player bar (narrow windows)

Below a certain width YouTube Music switches the player page into its mobile sheet layout
(`ytmusic-player-page[is-mweb-modernization-enabled]`), where `#side-panel` is `position: fixed` and
sized as:

```css
top: var(--ytmusic-player-page-player-bar-height);
height: calc(var(--ytmusic-player-page-inner-height) - var(--ytmusic-player-page-tabs-header-height));
```

With the sheet expanded (`player-page-ui-state="TABS_VIEW"`) that height makes the panel end at the
window bottom instead of the player bar's top edge, so the panel — and the `#tab-renderer` scrollbar
inside it, including its bottom arrow — is painted across the bar.

Letting the fixed panel resolve its height from `top`/`bottom` instead bounds it to the bar.
Measured in a 460x820 window (viewport 460x784, player bar top at y=720):

| | `#side-panel` bottom | `#tab-renderer` bottom | overlap past the bar |
| --- | --- | --- | --- |
| before | 780 | 780 | 60px |
| after | 720 | 720 | 0 |

Toggling the rule three times in one page session flips the overlap 60 <-> 0 every cycle. In a real
1865x1110 window every measured field is identical with the rule on and off, so it is inert when the
layout is already correct. The scrollbar is kept, not suppressed: the gutter stays 15px and
`scrollHeight > clientHeight` still holds, so the tab content remains scrollable.

## 2. The page scrollbar runs down the side of the player bar (all widths)

On browse pages the document itself scrolls, so the classic scrollbar spans the whole window,
including alongside the fixed player bar. YTM reserves that width, so the bar cannot reach the window
edge and the scrollbar's arrow sits at the bar's right end. With the player page open the document
does not scroll and the problem disappears, which is why it looks intermittent.

Measured on a scrollable browse page at 1866x1074, from a built package:

| | root scrollbar | player bar background right edge | scrolling |
| --- | --- | --- | --- |
| before | 16px | 1850 (window is 1866) | works |
| after | 0 | 1866, i.e. the window edge | works |

**This one is a judgement call and I would rather flag it than slip it in.** `scrollbar-width: none`
on the root removes the page scroll indicator in the YTM view; the wheel, trackpad and keyboard still
scroll, and inner scrollers (the queue, the side panel) keep their own scrollbars. It is what mobile
YTM looks like. If you would rather not change this for everyone, I am happy to move it behind a
setting, or to drop the second commit and land only the first.

I also tried the less invasive-looking alternative of moving the scroll to `<body>` so the scrollbar
would end at the bar. It does not work: with `overflow: visible` on the root, body's overflow
propagates to the viewport rather than making body a scroll container, and forcing the root to
`hidden` at load time loses the cascade against YTM's own `body { overflow: hidden }` — which leaves
the page unable to scroll at all. I only caught that because the verification asserts that scrolling
still works, so that assertion is worth keeping in mind for anyone touching this area.

## Notes

Related to #1784. This covers the scrollbar half of that report; the top-bar and stuck-interaction
symptoms described there are not addressed, so it is deliberately not marked as fixing it. This
replaces #1792, which I withdrew because it only had the first of the two fixes.

Environment: Linux (GNOME/Wayland), YTMDesktop 2.0.11, Electron 40.
