### PR TITLE
✨ Close the window with Ctrl+W

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,7 +16,8 @@ import {
   screen,
   session,
   shell,
-  Tray
+  Tray,
+  WebContents
 } from "electron";
 import Conf from "conf";
 import log from "electron-log";
@@ -697,6 +698,21 @@ function setTrayIcon() {
   tray.setImage(getTrayIconPath());
 }
 
+// The app has no window-scoped shortcuts of its own: the application menu is null on Windows and
+// Linux, and globalShortcut is system-wide, so binding Ctrl+W there would swallow it from every
+// other app. before-input-event is the only way to listen inside a window.
+function registerCloseWindowShortcut(webContents: WebContents, close: () => void) {
+  webContents.on("before-input-event", (event, input) => {
+    if (input.type !== "keyDown") return;
+    if (input.key.toLowerCase() !== "w") return;
+    if (input.alt || input.shift) return;
+    if (isDarwin ? !input.meta || input.control : !input.control || input.meta) return;
+
+    event.preventDefault();
+    close();
+  });
+}
+
 // Shortcut registration
 function registerShortcuts() {
   const shortcuts = store.get("shortcuts");
@@ -955,6 +971,7 @@ const createOrShowSettingsWindow = (): void => {
   });
 
   // Attach events to settings window
+  registerCloseWindowShortcut(settingsWindow.webContents, () => settingsWindow?.close());
   settingsWindow.on("maximize", sendSettingsWindowStateIpc);
   settingsWindow.on("unmaximize", sendSettingsWindowStateIpc);
   settingsWindow.on("minimize", sendSettingsWindowStateIpc);
@@ -1035,6 +1052,8 @@ const createYTMView = (): void => {
   ratioVolume.provide(ytmView);
 
   // Attach events to ytm view
+  // The YTM page owns focus nearly always, so without this Ctrl+W would look dead in normal use.
+  registerCloseWindowShortcut(ytmView.webContents, () => mainWindow?.close());
   ytmView.webContents.on("will-navigate", event => {
     const url = new URL(event.url);
     if (isPreventedNavOrRedirect(url)) {
@@ -1285,6 +1304,8 @@ const createMainWindow = (): void => {
   mainWindow.on("unmaximize", sendMainWindowStateIpc);
   mainWindow.on("minimize", sendMainWindowStateIpc);
   mainWindow.on("restore", sendMainWindowStateIpc);
+  registerCloseWindowShortcut(mainWindow.webContents, () => mainWindow?.close());
+
   mainWindow.on("close", event => {
     if (!applicationQuitting && (store.get("general").hideToTrayOnClose || isDarwin)) {
       event.preventDefault();
@@ -1508,11 +1529,10 @@ app.on("ready", async () => {
     if (mainWindow !== null) {
       if (event.sender !== mainWindow.webContents) return;
 
-      if (store.get("general").hideToTrayOnClose || isDarwin) {
-        mainWindow.hide();
-      } else {
-        app.quit();
-      }
+      // Go through the window's own close handler so the titlebar button, Alt+F4 and Ctrl+W all
+      // take one path. Deciding hide-vs-quit here as well left the two out of step, and skipping
+      // the close event meant the window bounds were never saved on the hide path.
+      mainWindow.close();
     }
   });
 


### PR DESCRIPTION
Closes #1802. Fixes #1801.

## Summary

Adds Ctrl+W (Cmd+W on macOS) as a close-window shortcut, and routes the titlebar close button through the same handler as Alt+F4 so all three behave identically.

## Ctrl+W

The app had no window-scoped keyboard handling at all: there is no `before-input-event` anywhere, no local-shortcut library, and the application menu is `null` on Windows and Linux for performance, so there were no menu accelerators to inherit. `globalShortcut` is the wrong tool here — it is system-wide and would swallow Ctrl+W from every other application — so a `before-input-event` listener is used instead.

The listener is registered on three `webContents`, each closing only its own window:

| `webContents` | Closes |
| --- | --- |
| `mainWindow.webContents` | main window |
| `ytmView.webContents` | main window |
| `settingsWindow.webContents` | settings window |

Registering on the YTM `BrowserView` is what makes this work in practice: the main window's own `webContents` is just the 36px titlebar, and the YouTube Music page holds focus nearly all of the time. A renderer-side `keydown` would not have worked either, since an IPC send from the YTM view is rejected by the existing `event.sender !== mainWindow.webContents` guard on `mainWindow:close`.

The settings window is `modal: !isDarwin` with `parent: mainWindow`, so it gets its own registration that closes itself rather than the parent underneath it.

The guard requires exactly one platform modifier — Cmd on macOS, Ctrl elsewhere — and rejects Alt or Shift, so Ctrl+Shift+W and Cmd+Ctrl+W do not trigger it. `event.preventDefault()` stops the page from also seeing the key.

The companion-server authorization windows are intentionally out of scope; they have request-scoped lifetimes and their own close channels.

## Close-path consistency

`mainWindow:close` (the titlebar X button) duplicated the hide-vs-quit decision that `mainWindow.on("close")` already makes, and the two had drifted apart:

```ts
// before
ipcMain.on("mainWindow:close", event => {
  if (mainWindow !== null) {
    if (event.sender !== mainWindow.webContents) return;
    if (store.get("general").hideToTrayOnClose || isDarwin) {
      mainWindow.hide();
    } else {
      app.quit();
    }
  }
});
```

Calling `hide()` directly skips the `close` event, so **the window bounds and maximized state were never saved when the titlebar button hid the app to tray**. Alt+F4 saved them, because it goes through `close`. The X button now calls `mainWindow.close()`, leaving `mainWindow.on("close")` as the single place that decides hide-vs-quit.

Behaviour is otherwise unchanged. With `hideToTrayOnClose` off on a non-macOS platform, the old path called `app.quit()` directly; the new path destroys the window, which fires `window-all-closed` and quits there instead — same outcome, plus the state save.

## Verification

- `tsc --noEmit` and ESLint report the same pre-existing findings as the base branch, and no new ones
- `yarn make --targets deb`, with `.desktop` categories and installed icon verified
- The modifier guard was exercised as a table of 13 cases (Ctrl+W, bare W, Ctrl+Shift+W, Ctrl+Alt+W, Super+W, Ctrl+Super+W, Ctrl+Q, keyUp, uppercase W, and the macOS Cmd/Ctrl variants); all behave as intended
- Manual runtime verification on Ubuntu 26.04.1, GNOME Shell 50.1, Wayland, x64, installed from the built `.deb`:
  - Ctrl+W with focus in the YouTube Music page, and with focus in the titlebar
  - Ctrl+W with focus in the YouTube Music search field
  - Ctrl+W in the settings window closes only the settings window
  - Ctrl+Shift+W does nothing
  - X button, Alt+F4 and Ctrl+W match with `hideToTrayOnClose` both on and off
  - Window position and size survive hiding to tray with the titlebar button, which is the #1801 regression

## Known limitations

- macOS and Windows were not tested on real hardware. The Cmd+W branch was verified by reading and by the modifier-guard cases only. On macOS the existing `close` handler always hides rather than quits, which matches the platform convention for Cmd+W.
- The shortcut is fixed rather than user-configurable. Ctrl+W is conventional, and making it configurable would mean extending the shortcuts schema, the settings UI, and the registration-conflict reporting.
