### PR TITLE
🐛 Keep the main window on screen when its display is gone

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1198,10 +1198,40 @@ const createYTMView = (): void => {
   }, 30 * 1000);
 };
 
+// Window bounds are restored from the store on every launch which means bounds saved on a display that is no longer connected
+// (or that has since moved within the display layout) place the window off-screen where it can't be reached, and restarting the
+// application doesn't help because the very same bounds get applied again
+const ensureBoundsAreVisible = (bounds: Electron.Rectangle): Electron.Rectangle => {
+  // Enough of the window has to overlap a display for its title bar to still be grabbable
+  const minimumVisibleSize = 64;
+  const boundsAreVisible = screen.getAllDisplays().some(display => {
+    const workArea = display.workArea;
+    const visibleWidth = Math.min(bounds.x + bounds.width, workArea.x + workArea.width) - Math.max(bounds.x, workArea.x);
+    const visibleHeight = Math.min(bounds.y + bounds.height, workArea.y + workArea.height) - Math.max(bounds.y, workArea.y);
+    return visibleWidth >= Math.min(minimumVisibleSize, bounds.width) && visibleHeight >= Math.min(minimumVisibleSize, bounds.height);
+  });
+
+  if (boundsAreVisible) {
+    return bounds;
+  }
+
+  // Center the window on whichever display sits closest to the saved bounds
+  const workArea = screen.getDisplayMatching(bounds).workArea;
+  const width = Math.min(bounds.width, workArea.width);
+  const height = Math.min(bounds.height, workArea.height);
+  return {
+    width,
+    height,
+    x: Math.round(workArea.x + (workArea.width - width) / 2),
+    y: Math.round(workArea.y + (workArea.height - height) / 2)
+  };
+};
+
 const createMainWindow = (): void => {
   // Create the browser window.
   const scaleFactor = screen.getPrimaryDisplay().scaleFactor;
-  const windowBounds = store.get("state").windowBounds;
+  const savedBounds = store.get("state").windowBounds;
+  const windowBounds = savedBounds ? ensureBoundsAreVisible(savedBounds) : null;
   mainWindow = new BrowserWindow({
     width: windowBounds?.width ?? 1280 / scaleFactor,
     height: windowBounds?.height ?? 720 / scaleFactor,


### PR DESCRIPTION
### The problem

`createMainWindow` applies `state.windowBounds` exactly as it was saved, on every launch. When those bounds were saved while the window sat on a display that is no longer connected — or the display layout has changed since — the window is placed where no display covers it. The app looks like it started (tray icon, media keys and audio all work) but the window can't be reached, and because the same coordinates are applied again next time, restarting the app or rebooting doesn't recover it either.

Windows does normally pull a window off a disconnected display back onto a connected one, but the `setBounds` call right after the window is created undoes that correction.

That leaves reconnecting the monitor or hand-editing `config.json` as the only ways out, which is what #1282 has been collecting reports about. V1 had a check for this (#840); it didn't make it into V2.

Fixes #1282

### The change

`ensureBoundsAreVisible` validates the saved bounds against `screen.getAllDisplays()` before they reach the `BrowserWindow` constructor:

- bounds overlapping some display's work area by at least 64×64 px are used unchanged, so multi-monitor setups and windows deliberately parked half off a screen edge behave exactly as they do today
- anything less visible than that is re-centered on the display closest to the saved bounds (`screen.getDisplayMatching`), keeping the saved size clamped to that display's work area

The 64 px floor is there because a window with a handful of visible pixels is technically on a display but still can't be grabbed by its title bar — the same reasoning as the `+ 64` in #840. For windows smaller than that (only reachable by editing the store, since `minWidth`/`minHeight` are 156/180) the check falls back to requiring the full dimension to be visible.

Saving is left alone: bounds are still stored verbatim on close, so reconnecting the display restores the window where it was left.

### Testing

Packaged with `yarn package` and launched against a scratch `--user-data-dir`, on Windows 11 with a single 2560×1600 display at 150% scaling (work area 1707×1019 DIP). Positions below are Electron's, after subtracting Windows' invisible resize border from the measured window rect:

| saved `windowBounds` | result |
| --- | --- |
| `x: -1315, y: 793, 812×494` — taken from a real occurrence of this bug, window left on a secondary display that was then disconnected | opens centered at `448, 263`, saved size kept |
| `x: 1706, y: 100, 812×494` — 1 px on screen | re-centered to `448, 263` |
| `x: 300, y: 200, 900×600` — ordinary on-screen bounds | restored exactly as saved |

The display-intersection maths was checked separately against a table of cases, including ones I can't reproduce on this machine: bounds on a still-connected secondary display (left alone), a window hanging off the right edge with 200 px and with exactly 64 px still visible (left alone), title bar below the work area (re-centered), and saved bounds larger than the current display (clamped to the work area).

`yarn lint` is clean apart from the two `import/no-named-as-default` warnings already present on `development`.
